### PR TITLE
[no-jira] withdraw creating tablespace for postgre

### DIFF
--- a/src/test/resources/docker/postgres-init.sh
+++ b/src/test/resources/docker/postgres-init.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir -p /tmp/tablespace/liquibase2
-
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
     CREATE USER lbuser WITH PASSWORD 'LiquibasePass1';
-    CREATE TABLESPACE liquibase2 OWNER lbuser LOCATION '/tmp/tablespace/liquibase2';
     GRANT ALL PRIVILEGES ON DATABASE lbcat TO lbuser;
     GRANT ALL PRIVILEGES ON SCHEMA public TO lbuser;
 


### PR DESCRIPTION
We don't need to create separate tablespace for postge. At least for now. Removed that part as quick fix as it fails for docker-desktop 2.4.0.0 on Mac OS and 2.4.0.1 on Windows