### PR TITLE
[no-jira] fixed case when DB version is not provided

### DIFF
--- a/src/main/groovy/liquibase/sdk/test/ChangeObjectTests.groovy
+++ b/src/main/groovy/liquibase/sdk/test/ChangeObjectTests.groovy
@@ -2,10 +2,7 @@ package liquibase.sdk.test
 
 import liquibase.CatalogAndSchema
 import liquibase.Liquibase
-import liquibase.Scope
 import liquibase.database.jvm.JdbcConnection
-import liquibase.lockservice.LockServiceFactory
-import liquibase.lockservice.MockLockService
 import liquibase.sdk.test.config.TestConfig
 import liquibase.sdk.test.util.FileUtils
 import liquibase.sdk.test.util.SnapshotHelpers

--- a/src/main/groovy/liquibase/sdk/test/config/TestConfig.groovy
+++ b/src/main/groovy/liquibase/sdk/test/config/TestConfig.groovy
@@ -83,7 +83,13 @@ class TestConfig {
                     } else {
                         databaseUnderTest.name += " ${databaseUnderTest.database.getDatabaseProductVersion()}"
                     }
-                } else if (databaseUnderTest.name != databaseUnderTest.database.shortName ||
+                } else if (databaseUnderTest.version == null) {
+                    Logger.getLogger(this.class.name)
+                            .warning("Database version is not provided applying version from Database metadata")
+                    databaseUnderTest.version = databaseUnderTest.database.getDatabaseMajorVersion() + "."
+                    +databaseUnderTest.database.getDatabaseMinorVersion()
+                }
+                else if (databaseUnderTest.name != databaseUnderTest.database.shortName ||
                         !databaseUnderTest.version.startsWith(databaseUnderTest.database.databaseMajorVersion.toString())) {
                     Logger.getLogger(this.class.name).severe("Provided database name/majorVersion doesn't match with actual\
 ${System.getProperty("line.separator")}    provided: ${databaseUnderTest.name} ${databaseUnderTest.version}\
@@ -94,8 +100,5 @@ ${databaseUnderTest.database.databaseMajorVersion.toString()}")
         }
         return instance
 
-    }
-    static void setInstance(TestConfig instance) {
-        TestConfig.instance = instance
     }
 }


### PR DESCRIPTION
for some DBs, like cloud ones, we don't really now what version is on server.
Added support for case when DB version is not provided in yaml file, we get it from DB connection.