### PR TITLE
Correctly lookup test-harness using static-compatible code

### DIFF
--- a/src/main/groovy/liquibase/harness/config/TestConfig.groovy
+++ b/src/main/groovy/liquibase/harness/config/TestConfig.groovy
@@ -31,7 +31,7 @@ class TestConfig {
     static TestConfig getInstance() {
         if (instance == null) {
             Yaml configFileYml = new Yaml()
-            def testConfig = getClass().getResourceAsStream("/harness-config.yml")
+            def testConfig = TestConfig.class.getResourceAsStream("/harness-config.yml")
             assert testConfig != null : "Cannot find harness-config.yml in classpath"
 
             instance = configFileYml.loadAs(testConfig, TestConfig.class)


### PR DESCRIPTION
Lookup was failing on java 11+

This fix makes the cassandra tests pass on 11 and 16