### PR TITLE
createTableTimestamp: Add column type to snapshot validation.

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/createTableTimestamp.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/createTableTimestamp.json
@@ -14,7 +14,10 @@
             "name": "lms_test_id"
           },
           "column": {
-            "name": "lms_test_timestamp"
+            "name": "lms_test_timestamp",
+            "type": {
+              "typeName": "timestamp"
+            }
           }
         }
       ]


### PR DESCRIPTION
This is a very minor addition to the expected results snapshot file for createTableTimestamp. This way, we validate that not only does the column exists, but that it is of the correct datatype.