### PR TITLE
[DAT-7066] Removed -Dmaven.test.failure.ignore=true for mariadb, mysql.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         run: docker-compose up -d
 
       - name: MySQL Test Run
-        run: mvn -Dtest=LiquibaseHarnessSuiteTest -DdbName=mysql -Dmaven.test.failure.ignore=true test
+        run: mvn -Dtest=LiquibaseHarnessSuiteTest -DdbName=mysql test
 
       - name: Archive MySQL test results
         uses: actions/upload-artifact@v2
@@ -39,7 +39,7 @@ jobs:
           path: build/spock-reports
 
       - name: MariaDB Test Run
-        run: mvn -Dtest=LiquibaseHarnessSuiteTest -DdbName=mariadb -Dmaven.test.failure.ignore=true test
+        run: mvn -Dtest=LiquibaseHarnessSuiteTest -DdbName=mariadb test
 
       - name: Archive MariaDB test results
         uses: actions/upload-artifact@v2

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mssql/createTableTimestamp.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mssql/createTableTimestamp.json
@@ -1,0 +1,26 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "lms_create_table_test"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "lms_test_id"
+          },
+          "column": {
+            "name": "lms_test_timestamp",
+            "type": {
+              "typeName": "datetime"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/docker/mysql-init.sql
+++ b/src/test/resources/docker/mysql-init.sql
@@ -1,5 +1,4 @@
 GRANT ALL PRIVILEGES ON lbcat.* TO 'lbuser'@'%';
-GRANT PROCESS, SELECT, CREATE ROUTINE, ALTER ROUTINE ON lbcat.* TO 'lbuser'@'%';
 
 DROP TABLE IF EXISTS `authors`;
 CREATE TABLE `authors` (


### PR DESCRIPTION
Removed additional priviliges granting for mysql-init.sql because it somehow breaks permissions for docker container.
Fixed wrong expected snapshot for createTableTimestamp test for mssql