### PR TITLE
Updated primary key on DATABASECHANGELOG

### DIFF
--- a/src/test/resources/docker/percona-xtradb-cluster-init.sql
+++ b/src/test/resources/docker/percona-xtradb-cluster-init.sql
@@ -33,7 +33,7 @@ CREATE TABLE `DATABASECHANGELOG` (
                           `CONTEXTS` varchar(255) DEFAULT NULL,
                           `LABELS` varchar(255) DEFAULT NULL,
                           `DEPLOYMENT_ID` varchar(10) DEFAULT NULL,
-                          PRIMARY KEY (ID)
+                          PRIMARY KEY (ID, AUTHOR, FILENAME)
 ) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 DROP TABLE IF EXISTS `authors`;


### PR DESCRIPTION
Modified primary key to reflect that changesets are only identified uniquely by all three fields (id, author, and filename) not just by ID alone. The primary key of this table should reflect that to ensure integrity. ID by itself is not guaranteed to be unique by Liquibase