### PR TITLE
DAT-9484 remove support for Oracle RDS 12.2 due to vendor deprecation

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -95,8 +95,6 @@ jobs:
           - database: oracle
             version: 12-1
           - database: oracle
-            version: 12-2
-          - database: oracle
             version: 19
 
     steps:

--- a/src/test/resources/terraform/oracle.tf
+++ b/src/test/resources/terraform/oracle.tf
@@ -1,8 +1,8 @@
 # Versions of oracle to create. 
 variable "oracleVersion" {
   type        = list(string)
-  description = "Oracle Database Engine Version (example: 12.1, 12.2, 19)"
-  default     = ["12.1", "12.2", "19"]
+  description = "Oracle Database Engine Version (example: 12.1, 19)"
+  default     = ["12.1", "19"]
 }
 
 # Create the security group granting access to the database with a source of the public IP of the runner


### PR DESCRIPTION
AWS has deprecated Oracle RDS 12.2

Test Run here: https://github.com/liquibase/liquibase-test-harness/actions/runs/1884176826