### PR TITLE
PR-2387: Test to validate datetime handling in loadData.

### DIFF
--- a/src/main/groovy/liquibase/harness/base/BaseLevelTest.groovy
+++ b/src/main/groovy/liquibase/harness/base/BaseLevelTest.groovy
@@ -7,6 +7,7 @@ import liquibase.harness.config.TestConfig
 import liquibase.harness.util.rollback.RollbackStrategy
 import org.json.JSONObject
 import org.junit.Assert
+import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -73,7 +74,7 @@ class BaseLevelTest extends Specification {
             connection.commit()
             def expectedResultSetJSON = new JSONObject(expectedResultSet)
             def expectedResultSetArray = expectedResultSetJSON.getJSONArray(testInput.change)
-            assert compareJSONArraysExtensible(generatedResultSetArray, expectedResultSetArray)
+            assert compareJSONArrays(generatedResultSetArray, expectedResultSetArray, JSONCompareMode.LENIENT)
         } catch (Exception exception) {
             Scope.getCurrentScope().getUI().sendMessage("Error executing checking sql! " + exception.printStackTrace())
             Assert.fail exception.message

--- a/src/main/groovy/liquibase/harness/data/ChangeDataTests.groovy
+++ b/src/main/groovy/liquibase/harness/data/ChangeDataTests.groovy
@@ -8,6 +8,7 @@ import liquibase.harness.util.rollback.RollbackStrategy
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Assume
+import org.skyscreamer.jsonassert.JSONCompareMode
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -92,7 +93,7 @@ class ChangeDataTests extends Specification {
             connection.commit()
             def expectedResultSetJSON = new JSONObject(expectedResultSet)
             def expectedResultSetArray = expectedResultSetJSON.getJSONArray(testInput.getChangeData())
-            assert compareJSONArrays(generatedResultSetArray, expectedResultSetArray)
+            assert compareJSONArrays(generatedResultSetArray, expectedResultSetArray, JSONCompareMode.NON_EXTENSIBLE)
         } catch (Exception exception) {
             Scope.getCurrentScope().getUI().sendMessage("Error executing checking sql! " + exception.printStackTrace())
             Assert.fail exception.message

--- a/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
+++ b/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
@@ -62,7 +62,7 @@ class JSONUtils {
      * Compares exactly number and values of elements in JSON arrays. Ignores order of elements.
      * Works only on the 1st level of nesting. Compare mode NON_EXTENSIBLE.
      */
-    static boolean compareJSONArrays(JSONArray jsonArray, JSONArray jsonArrayToCompare) {
+    static boolean compareJSONArrays(JSONArray jsonArray, JSONArray jsonArrayToCompare, JSONCompareMode jsonCompareMode) {
         if (jsonArray.length() != jsonArrayToCompare.length()) {
             return false
         }
@@ -75,35 +75,9 @@ class JSONUtils {
                 def jsonObjectRight = new JSONObject(jsonArray.get(i).toString())
                 def jsonObjectLeft = new JSONObject(jsonArrayToCompare.get(j).toString())
                 def result = JSONCompare.compareJSON(jsonObjectLeft, jsonObjectRight,   new CustomComparator(
-                        JSONCompareMode.NON_EXTENSIBLE,
+                        jsonCompareMode,
                         new Customization("***", new RegularExpressionValueMatcher<>())
                 ))
-                compareMarker = result.passed()
-                if (result.passed()) {
-                    break
-                }
-            }
-        }
-        return compareMarker
-    }
-
-    /**
-     * Compares values of elements in JSON arrays. Ignores order of elements.
-     * Works only on the 1st level of nesting. Compare mode LENIENT.
-     */
-    static boolean compareJSONArraysExtensible(JSONArray jsonArray, JSONArray jsonArrayToCompare) {
-        if (jsonArray.length() != jsonArrayToCompare.length()) {
-            return false
-        }
-        def compareMarker = true
-        for (int i = 0; i < jsonArray.length(); i++) {
-            if (!compareMarker) {
-                return false
-            }
-            for (int j = 0; j < jsonArrayToCompare.length(); j++) {
-                def jsonObjectRight = new JSONObject(jsonArray.get(i).toString())
-                def jsonObjectLeft = new JSONObject(jsonArrayToCompare.get(j).toString())
-                def result = JSONCompare.compareJSON(jsonObjectLeft, jsonObjectRight, JSONCompareMode.LENIENT)
                 compareMarker = result.passed()
                 if (result.passed()) {
                     break

--- a/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
+++ b/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
@@ -70,7 +70,7 @@ class JSONUtils {
             for (int j = 0; j < jsonArrayToCompare.length(); j++) {
                 def jsonObjectRight = new JSONObject(jsonArray.get(i).toString())
                 def jsonObjectLeft = new JSONObject(jsonArrayToCompare.get(j).toString())
-                def result = JSONCompare.compareJSON(jsonObjectLeft, jsonObjectRight, JSONCompareMode.NON_EXTENSIBLE)
+                def result = JSONCompare.compareJSON(jsonObjectLeft, jsonObjectRight, JSONCompareMode.LENIENT)
                 compareMarker = result.passed()
                 if (result.passed()) {
                     break

--- a/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
+++ b/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
@@ -4,8 +4,12 @@ import groovy.json.JsonSlurper
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import org.skyscreamer.jsonassert.Customization
 import org.skyscreamer.jsonassert.JSONCompare
 import org.skyscreamer.jsonassert.JSONCompareMode
+import org.skyscreamer.jsonassert.RegularExpressionValueMatcher
+import org.skyscreamer.jsonassert.comparator.CustomComparator
+
 import java.sql.ResultSet
 import java.sql.ResultSetMetaData
 import java.sql.SQLException
@@ -70,7 +74,10 @@ class JSONUtils {
             for (int j = 0; j < jsonArrayToCompare.length(); j++) {
                 def jsonObjectRight = new JSONObject(jsonArray.get(i).toString())
                 def jsonObjectLeft = new JSONObject(jsonArrayToCompare.get(j).toString())
-                def result = JSONCompare.compareJSON(jsonObjectLeft, jsonObjectRight, JSONCompareMode.LENIENT)
+                def result = JSONCompare.compareJSON(jsonObjectLeft, jsonObjectRight,   new CustomComparator(
+                        JSONCompareMode.NON_EXTENSIBLE,
+                        new Customization("***", new RegularExpressionValueMatcher<>())
+                ))
                 compareMarker = result.passed()
                 if (result.passed()) {
                     break

--- a/src/main/resources/liquibase/harness/data/changelogs/h2/loadData.datatypes.datetime.csv
+++ b/src/main/resources/liquibase/harness/data/changelogs/h2/loadData.datatypes.datetime.csv
@@ -1,0 +1,4 @@
+id,date_col,datetime_col,time_col
+1,,,
+2,now,now,now
+3,2022-09-13,2022-09-13 12:34:56.789123,12:34:56

--- a/src/main/resources/liquibase/harness/data/changelogs/h2/loadData.datatypes.datetime.xml
+++ b/src/main/resources/liquibase/harness/data/changelogs/h2/loadData.datatypes.datetime.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+    <!-- Attribute "usePreparedStatements" is set to false because otherwise we can't validate generated query.
+    Reason: Liquibase core class BatchDmlExecutablePreparedStatementGenerator.java doesn't have implementation -->
+
+    <changeSet id="PR-2387" author="liquibase" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+        <createTable tableName="tbl_pr2387">
+            <column name="id" type="int"/>
+            <column name="date_col" type="date"/>
+            <column name="datetime_col" type="datetime"/>
+            <column name="time_col" type="time"/>
+        </createTable>
+        <loadData tableName="tbl_pr2387"
+                  file="loadData.datatypes.datetime.csv"
+                  usePreparedStatements="false"
+                  relativeToChangelogFile="true">
+            <column name="id" type="NUMERIC"/>
+            <column name="date_col" type="DATE"/>
+            <column name="datetime_col" type="DATETIME"/>
+            <column name="time_col" type="TIME"/>
+        </loadData>
+        <rollback>
+            <dropTable tableName="tbl_pr2387"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/data/checkingSql/h2/loadData.datatypes.datetime.sql
+++ b/src/main/resources/liquibase/harness/data/checkingSql/h2/loadData.datatypes.datetime.sql
@@ -1,0 +1,1 @@
+SELECT * FROM "tbl_pr2387"

--- a/src/main/resources/liquibase/harness/data/expectedResultSet/h2/loadData.datatypes.datetime.json
+++ b/src/main/resources/liquibase/harness/data/expectedResultSet/h2/loadData.datatypes.datetime.json
@@ -1,0 +1,19 @@
+{
+  "loadData.datatypes.datetime": [
+    {
+      "datetime_col":"",
+      "id":1,
+      "time_col":"",
+      "date_col":""
+    },
+    {
+      "id":2
+    },
+    {
+      "datetime_col":"2022-09-13 12:34:56.789123",
+      "id":3,
+      "time_col":"12:34:56",
+      "date_col":"2022-09-13"
+    }
+  ]
+}

--- a/src/main/resources/liquibase/harness/data/expectedResultSet/h2/loadData.datatypes.datetime.json
+++ b/src/main/resources/liquibase/harness/data/expectedResultSet/h2/loadData.datatypes.datetime.json
@@ -7,7 +7,10 @@
       "date_col":""
     },
     {
-      "id":2
+      "datetime_col": "\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
+      "id": 2,
+      "time_col": "\\d\\d:\\d\\d:\\d\\d",
+      "date_col": "\\d\\d\\d\\d-\\d\\d-\\d\\d"
     },
     {
       "datetime_col":"2022-09-13 12:34:56.789123",


### PR DESCRIPTION
[Liquibase PR](https://github.com/liquibase/liquibase/pull/2387)
[Liquibase Issue](https://github.com/liquibase/liquibase/issues/2383)

**Items of Note**

* The SQL in this test uses the `now()` function native to each database.
* This means that each time you run the test, the expected SQL will be different because `now` is never the same twice.
* I had to change the JSONCompareMode to LENIAT in JSONUtils.groovy; without this change, the test cannot pass.
  * If this is an unacceptable change, let me know. I can either close the pull request or revise according to your feedback.

This cannot be merged until the next release of Liquibase!