### PR TITLE
[no-jira] Tests report fix

### DIFF
--- a/src/main/groovy/liquibase/harness/change/ChangeObjectTests.groovy
+++ b/src/main/groovy/liquibase/harness/change/ChangeObjectTests.groovy
@@ -65,7 +65,7 @@ class ChangeObjectTests extends Specification {
                         "match generated sql! Deleting expectedSql file will test that new sql works correctly and " +
                         "will auto-generate a new version if it passes. \nEXPECTED SQL: \n" + expectedSql + " \n" +
                         "GENERATED SQL: \n" + generatedSql)
-                assert false
+                assert generatedSql == expectedSql
             }
             if (!TestConfig.instance.revalidateSql) {
                 return //sql is right. Nothing more to test

--- a/src/main/groovy/liquibase/harness/data/ChangeDataTests.groovy
+++ b/src/main/groovy/liquibase/harness/data/ChangeDataTests.groovy
@@ -78,7 +78,7 @@ class ChangeDataTests extends Specification {
                         "match generated sql! Deleting expectedSql file will test that new sql works correctly and " +
                         "will auto-generate a new version if it passes. \nEXPECTED SQL: \n" + expectedSql + " \n" +
                         "GENERATED SQL: \n" + generatedSql)
-                assert false
+                assert generatedSql == expectedSql
             }
             if (!TestConfig.instance.revalidateSql) {
                 return //sql is right. Nothing more to test


### PR DESCRIPTION
with `assert false`  reason why tests failed isn't shown in the bottom of the log. That makes it harder to quickly figure out reason why build failed. Fixed that