### PR TITLE
DAT-10559 deprecate postgres rds 9.6 and add support for 14

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -83,15 +83,15 @@ jobs:
       matrix:
         include:
           - database: postgresql
-            version: 9-6
-          - database: postgresql
             version: 10
           - database: postgresql
             version: 11
           - database: postgresql
             version: 12
           - database: postgresql
-            version: 13         
+            version: 13
+          - database: postgresql
+            version: 14        
           - database: oracle
             version: 12-1
           - database: oracle

--- a/src/test/resources/aws/postgres.tf
+++ b/src/test/resources/aws/postgres.tf
@@ -1,8 +1,8 @@
 # Versions of Postgresql to create. 
 variable "postgresqlVersion" {
   type        = list(string)
-  description = "Postgresql Database Engine Version (example: 9.6, 10, 11)"
-  default     = ["9.6", "10", "11", "12", "13"]
+  description = "Postgresql Database Engine Version (example: 10, 11, 12, 13, 14)"
+  default     = ["10", "11", "12", "13", "14"]
 }
 
 # Create the security group granting access to the database with a source of the public IP of the runner


### PR DESCRIPTION
AWS deprecated RDS Postgres 9.6.  Also added platform support for RDS Postgres 14.  All tests passing:
https://github.com/liquibase/liquibase-test-harness/actions/runs/2456101754