### PR TITLE
Added check for validate=false on addForeignKeyConstraint for Postgresql

### DIFF
--- a/src/main/resources/liquibase/harness/change/changelogs/postgresql/addForeignKeyNoValidate.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/postgresql/addForeignKeyNoValidate.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="oleh" id="1">
+        <addForeignKeyConstraint  baseColumnNames="author_id"
+                                  baseTableName="posts"
+                                  constraintName="fk_posts_authors_test"
+                                  onDelete="CASCADE"
+                                  onUpdate="RESTRICT"
+                                  referencedColumnNames="id"
+                                  referencedTableName="authors"
+                                  validate="false"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/addForeignKeyNoValidate.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/addForeignKeyNoValidate.json
@@ -1,0 +1,15 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.ForeignKey": [
+        {
+          "foreignKey": {
+            "deferrable": false,
+            "initiallyDeferred": false,
+            "name": "fk_posts_authors_test"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSql/postgresql/addForeignKeyNoValidate.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/postgresql/addForeignKeyNoValidate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.posts ADD CONSTRAINT fk_posts_authors_test FOREIGN KEY (author_id) REFERENCES public.authors (id) ON UPDATE RESTRICT ON DELETE CASCADE NOT VALID


### PR DESCRIPTION
## Description

PostgreSQL has implemented a feature, since version 9.1, that ensures that constraints are only checked for new or modified rows, but not for existing data. When defining a constraint, NOT VALID can be added at the end to make use of this feature. A similar feature is available in Oracle under the name of ENABLE NOVALIDATE. Currently, NOT VALID is only allowed for foreign key and check constraints.

Added test for liquibase/liquibase#2600