### PR TITLE
Don't use snapshots if the target branch for a PR is main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,10 @@ jobs:
             core.notice("Running in liquibase-test-harness branch " + testBranchName);
 
             let useLiquibaseSnapshot = testBranchName !== "main"
+            if ("${{ github.event.pull_request.base.ref }}" !== "") {
+              useLiquibaseSnapshot = "${{ github.event.pull_request.base.ref }}" !== "main"
+            }
+            
             console.log("useLiquibaseSnapshot == " + useLiquibaseSnapshot);
             core.setOutput("useLiquibaseSnapshot", useLiquibaseSnapshot);
 


### PR DESCRIPTION
## Description

The current logic works for PRs that are made to test new/changing liquibase functionality, but if a PR is based off `main` it will only consistently pass if it's being ran against a release build. 

For example, if we are adding a new platform for testing, but starting from `main` vs `develop`.

This changes the logic so we also take the target branch of the PR into account in deciding what version of liquibase to run