### PR TITLE
fix intermittent failure to do invalid user/pass

### DIFF
--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: src/test/resources
         run: |
           sed -i "s|USERNAME|${{ env.TH_USER }}|g" harness-config-snowflake.yml
-          sed -i "s|PASSWORD|${{ env.TH_PASS }}|g" harness-config-snowflake.yml
+          sed -i "s|PASSWORD|'${{ env.TH_PASS }}'|g" harness-config-snowflake.yml
 
       - name: Snowflake Test Run
         env:


### PR DESCRIPTION
job intermittently failing due to "unknown username or password" and I believe it's because the sed command was not escaping chars correctly.  Single quoting should fix.