### PR TITLE
log payload to help determine issue with scheduled build

### DIFF
--- a/.github/util/workflow-helper.js
+++ b/.github/util/workflow-helper.js
@@ -25,6 +25,7 @@ module.exports = ({github, context}) => {
         },
 
         getCurrentBranch: function () {
+            console.log(context.payload)
             if (context.payload.pull_request) {
                 return this.cleanBranchRef(context.payload.pull_request.head.ref);
             } else {


### PR DESCRIPTION
Scheduled build can't determine current branch so it uses Liquibase snapshot instead of released version of Liquibase.
This PR has to be merged to main as scheduled builds run only run on default branch 
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
and issue reproducers only for scheduled builds