### PR TITLE
use unique test-harness database name instead of lbcat due to conflicts

### DIFF
--- a/src/test/resources/harness-config-snowflake.yml
+++ b/src/test/resources/harness-config-snowflake.yml
@@ -5,6 +5,6 @@ databasesUnderTest:
   - name: snowflake
     prefix: cloud
     version:
-    url: jdbc:snowflake://ba89345.us-east-2.aws.snowflakecomputing.com/?db=LBCAT&schema=PUBLIC
+    url: jdbc:snowflake://ba89345.us-east-2.aws.snowflakecomputing.com/?db=LTHDB&schema=PUBLIC
     username: "USERNAME"
     password: "PASSWORD"

--- a/src/test/resources/snowflake/snowflake.tf
+++ b/src/test/resources/snowflake/snowflake.tf
@@ -15,7 +15,7 @@ resource "snowflake_role" "role" {
 
 resource "snowflake_database" "db" {
   provider = snowflake.sys_admin
-  name     = "LBCAT"
+  name     = "LTHDB"
 }
 resource "snowflake_database_grant" "grant" {
   provider          = snowflake.security_admin


### PR DESCRIPTION
LBCAT is getting created by some other manual or automated process in snowflake.  Changing name to something test-harness specific.