### PR TITLE
[no-jira] unignored dropColumn for mssql

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSql/mssql/dropColumn.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/mssql/dropColumn.sql
@@ -1,7 +1,3 @@
-INVALID TEST
--- Actually this test case has a bug and is marked INVALID in order to avoid ignoring whole platform at Github actions tests
--- https://github.com/liquibase/liquibase/issues/1818
-
 ALTER TABLE posts ADD varcharColumn varchar(25)
 UPDATE posts SET varcharColumn = 'INITIAL_VALUE'
 ALTER TABLE posts DROP COLUMN varcharColumn

--- a/src/main/resources/liquibase/harness/change/expectedSql/mssql/dropColumn.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/mssql/dropColumn.sql
@@ -1,0 +1,6 @@
+ALTER TABLE posts ADD varcharColumn varchar(25)
+UPDATE posts SET varcharColumn = 'INITIAL_VALUE'
+DECLARE @sql [nvarchar](MAX)
+SELECT @sql = N'ALTER TABLE posts DROP CONSTRAINT ' + QUOTENAME([df].[name]) FROM [sys].[columns] AS [c] INNER JOIN [sys].[default_constraints] AS [df] ON [df].[object_id] = [c].[default_object_id] WHERE [c].[object_id] = OBJECT_ID(N'posts') AND [c].[name] = N'varcharColumn'
+    EXEC sp_executesql @sql
+ALTER TABLE posts DROP COLUMN varcharColumn

--- a/src/main/resources/liquibase/harness/change/expectedSql/mssql/dropColumn.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/mssql/dropColumn.sql
@@ -1,3 +1,0 @@
-ALTER TABLE posts ADD varcharColumn varchar(25)
-UPDATE posts SET varcharColumn = 'INITIAL_VALUE'
-ALTER TABLE posts DROP COLUMN varcharColumn


### PR DESCRIPTION
Complicated query is required to drop constraints related to column. Looking a bit weird, but not breaking dropColumn logic.
Also checked SQL server on AWS - https://github.com/liquibase/liquibase-test-harness/actions/runs/3144653155/jobs/5110950175 works there as well 