### PR TITLE
Fix mariadb default collate upstream changes 

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.2/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.2/createFunction.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "com.datical.liquibase.ext.storedlogic.function.Function": [
+        {
+          "function": {
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "name": "test_function"
+          }
+        }]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.2/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.2/createPackage.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "com.datical.liquibase.ext.storedlogic.function.Function": [
+        {
+          "function": {
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "name": "test_function"
+          }
+        }]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.2/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.2/createPackageBody.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "com.datical.liquibase.ext.storedlogic.function.Function": [
+        {
+          "function": {
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "name": "test_function"
+          }
+        }]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createFunction.json
@@ -4,7 +4,6 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createFunction.json
@@ -5,6 +5,7 @@
         {
           "function": {
             "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createPackage.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.5/createPackageBody.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createFunction.json
@@ -5,6 +5,7 @@
         {
           "function": {
             "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createPackage.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createPackageBody.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createFunction.json
@@ -5,6 +5,7 @@
         {
           "function": {
             "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createPackage.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createPackageBody.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/createFunction.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1 COLLATE latin1_swedish_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/createPackage.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1 COLLATE latin1_swedish_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/createPackageBody.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET latin1 COLLATE latin1_swedish_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]


### PR DESCRIPTION
Mariadb is adding the collate by default when exporting function bodys  as per fix https://jira.mariadb.org/browse/MDEV-29446 . Changes tests to work accordly.