### PR TITLE
Fixed aws builds.

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Clean AWS MySQL Database
         uses: liquibase-github-actions/drop-all@v4.17.2
-        if: ${{ matrix.version == 'aws' }}
+        if: ${{ steps.setup.outputs.databaseVersion == 'aws' }}
         with:
           url: "${{ secrets.TH_MYSQLURL_8_0 }}"
           username: "${{secrets.TH_DB_ADMIN}}"
@@ -69,12 +69,12 @@ jobs:
           licenseKey: "${{secrets.LICENSE_KEY}}"
 
       - name: Init Database
-        if: ${{ matrix.version == 'aws' }}
+        if: ${{ steps.setup.outputs.databaseVersion == 'aws' }}
         run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_MYSQLURL_8_0 }}" update
 
       - name: Clean Aurora MySQL Database
         uses: liquibase-github-actions/drop-all@v4.17.2
-        if: ${{ matrix.version == 'aurora' }}
+        if: ${{ steps.setup.outputs.databaseVersion == 'aurora' }}
         with:
           url: "${{ secrets.TH_AURORA_MYSQLURL }}"
           username: "${{secrets.TH_DB_ADMIN}}"
@@ -82,7 +82,7 @@ jobs:
           licenseKey: "${{secrets.LICENSE_KEY}}"
 
       - name: Init Database
-        if: ${{ matrix.version == 'aurora' }}
+        if: ${{ steps.setup.outputs.databaseVersion == 'aurora' }}
         run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_AURORA_MYSQLURL }}" update
 
   test:
@@ -109,7 +109,7 @@ jobs:
       - uses: liquibase-github-actions/drop-all@v4.17.2
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
         with:
-          url: "${{ secrets[format('TH_ORACLEURL_{0}', matrix.version)] }}"
+          url: "${{ secrets[format('TH_ORACLEURL_{0}', steps.setup.outputs.databaseVersion)] }}"
           username: "${{secrets.TH_DB_ADMIN}}"
           password: "${{secrets.TH_DB_PASSWD}}"
           licenseKey: "${{secrets.LICENSE_KEY}}"
@@ -127,7 +127,7 @@ jobs:
       - uses: liquibase-github-actions/drop-all@v4.17.2
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion != 'aurora' }}
         with:
-          url: "${{ secrets[format('TH_PGRESURL_{0}', matrix.version)] }}"
+          url: "${{ secrets[format('TH_PGRESURL_{0}', steps.setup.outputs.databaseVersion)] }}"
           username: "${{secrets.TH_DB_ADMIN}}"
           password: "${{secrets.TH_DB_PASSWD}}"
           licenseKey: "${{secrets.LICENSE_KEY}}"

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Clean Aurora MySQL Database
         uses: liquibase-github-actions/drop-all@v4.17.2
-        if: ${{ matrix.version == 'aws' }}
+        if: ${{ matrix.version == 'aurora' }}
         with:
           url: "${{ secrets.TH_AURORA_MYSQLURL }}"
           username: "${{secrets.TH_DB_ADMIN}}"
@@ -82,7 +82,7 @@ jobs:
           licenseKey: "${{secrets.LICENSE_KEY}}"
 
       - name: Init Database
-        if: ${{ matrix.version == 'aws' }}
+        if: ${{ matrix.version == 'aurora' }}
         run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_AURORA_MYSQLURL }}" update
 
   test:

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -22,7 +22,7 @@ on:
       databases:
         description: Databases to start up. Comma separated list of "name:version"
         required: true
-        default: "[\"postgresql:10\",\"postgresql:11\",\"postgresql:12\",\"postgresql:13\",\"postgresql:14\",\"oracle:19\",\"mariadb:10.6\",\"mysql:aws\",
+        default: "[\"postgresql:10\",\"postgresql:11\",\"postgresql:12\",\"postgresql:13\",\"postgresql:14\",\"oracle:19\",\"mariadb:aws_10.6\",\"mysql:aws\",
         \"mysql:aurora\",\"mssql:2019\",\"postgresql:aurora\"]"
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       databases: ${{ github.event.inputs.databases || '["postgresql:10","postgresql:11","postgresql:12","postgresql:13","postgresql:14","oracle:19",
-        "mariadb:10.6","mysql:aws","mysql:aurora","mssql:2019","postgresql:aurora"]' }}
+        "mariadb:aws_10.6","mysql:aws","mysql:aurora","mssql:2019","postgresql:aurora"]' }}
       testClasses: ${{ inputs.testClasses  || 'LiquibaseHarnessSuiteTest' }}
     steps:
       - name: Checkout

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Clean AWS MySQL Database
         uses: liquibase-github-actions/drop-all@v4.17.2
-        if: ${{ steps.setup.outputs.databaseVersion == 'aws' }}
+        if: ${{ matrix.version == 'aws' }}
         with:
           url: "${{ secrets.TH_MYSQLURL_8_0 }}"
           username: "${{secrets.TH_DB_ADMIN}}"
@@ -69,7 +69,7 @@ jobs:
           licenseKey: "${{secrets.LICENSE_KEY}}"
 
       - name: Init Database
-        if: ${{ steps.setup.outputs.databaseVersion == 'aws' }}
+        if: ${{ matrix.version == 'aws' }}
         run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_MYSQLURL_8_0 }}" update
 
       - name: Clean Aurora MySQL Database

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Clean Aurora MySQL Database
         uses: liquibase-github-actions/drop-all@v4.17.2
-        if: ${{ steps.setup.outputs.databaseVersion == 'aurora' }}
+        if: ${{ matrix.version == 'aws' }}
         with:
           url: "${{ secrets.TH_AURORA_MYSQLURL }}"
           username: "${{secrets.TH_DB_ADMIN}}"
@@ -82,7 +82,7 @@ jobs:
           licenseKey: "${{secrets.LICENSE_KEY}}"
 
       - name: Init Database
-        if: ${{ steps.setup.outputs.databaseVersion == 'aurora' }}
+        if: ${{ matrix.version == 'aws' }}
         run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}.sql" --username="${{ secrets.TH_DB_ADMIN }}" --password="${{ secrets.TH_DB_PASSWD }}" --url="${{ secrets.TH_AURORA_MYSQLURL }}" update
 
   test:

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.6/createFunction.json
@@ -4,7 +4,6 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/10.7/createFunction.json
@@ -4,7 +4,6 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createFunction.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "com.datical.liquibase.ext.storedlogic.function.Function": [
+        {
+          "function": {
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "name": "test_function"
+          }
+        }]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackage.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "com.datical.liquibase.ext.storedlogic.function.Function": [
+        {
+          "function": {
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "name": "test_function"
+          }
+        }]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackageBody.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "com.datical.liquibase.ext.storedlogic.function.Function": [
+        {
+          "function": {
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "name": "test_function"
+          }
+        }]
+    }
+  }
+}

--- a/src/test/resources/harness-config-cloud.yml
+++ b/src/test/resources/harness-config-cloud.yml
@@ -32,7 +32,7 @@ databasesUnderTest:
 
   - name: mariadb
     prefix: aws
-    version: 10.6
+    version: aws_10.6
     url: DBENDPOINT
     username: USERNAME
     password: PASSWORD


### PR DESCRIPTION
1. Now `steps.setup.outputs.databaseVersion` is used instead of `matrix.version` in aws.yml  for Oracle and Postgres.
2. Created aws_10.6 directory with test data for AWS MariaDB runs. 

green aws builds are here: 
https://github.com/liquibase/liquibase-test-harness/actions/runs/3489252293
https://github.com/liquibase/liquibase-test-harness/actions/runs/3489979917