### PR TITLE
[no-jira] override modifySql changelog for Oracle 19 on AWS

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSql/oracle/19/modifySql.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/oracle/19/modifySql.sql
@@ -1,0 +1,1 @@
+/* prepend comment */ CREATE TABLE LBUSER.test_table (test_id INTEGER NOT NULL, test_column VARCHAR2(50) NOT NULL) -- append comment


### PR DESCRIPTION
AWS build fails because of Oracle 19 modifySql testcase fails with expectedSQL=
``` /* prepend comment */ CREATE TABLE "C##LIQUIBASE".test_table (test_id INTEGER NOT NULL, test_column VARCHAR2(50) NOT NULL) -- append comment``` but should be 
```/* prepend comment */ CREATE TABLE LBUSER.test_table (test_id INTEGER NOT NULL, test_column VARCHAR2(50) NOT NULL) -- append comment```
as for AWS we have different user than for regular Oracle workflow run