### PR TITLE
DAT-13155 Remove unnecessary parentheses from dropFunction Change Type

### DIFF
--- a/src/main/resources/liquibase/harness/change/changelogs/snowflake/createFunction.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/snowflake/createFunction.xml
@@ -14,7 +14,7 @@
                 ;
         </pro:createFunction>
         <rollback>
-            <pro:dropFunction functionName="test_function()"/>
+            <pro:dropFunction functionName="test_function"/>
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/snowflake/dropFunction.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/snowflake/dropFunction.xml
@@ -16,7 +16,7 @@
         <rollback/>
     </changeSet>
     <changeSet author="as" id="2">
-        <pro:dropFunction functionName="test_function()"/>
+        <pro:dropFunction functionName="test_function"/>
         <rollback/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
They are automatically added by generateSql method

Snowflake Cloud workflow is passed - https://github.com/liquibase/liquibase-test-harness/actions/runs/4023232260