### PR TITLE
[no-jira] Snowflake createTableDataTypeDoubleIsFloat testcase fix

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/snowflake/createTableDataTypeDoubleIsFloat.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/snowflake/createTableDataTypeDoubleIsFloat.json
@@ -13,7 +13,7 @@
           "column": {
             "name": "FLOATCOL",
             "type": {
-              "typeName": "FLOAT"
+              "typeName": "DOUBLE"
             }
           }
         }


### PR DESCRIPTION
In order to createTableDataTypeDoubleIsFloat testcase work with latest core changes expected "typeName" should be "DOUBLE"