### PR TITLE
DAT-15369] Rollback snowflake driver to 3.13.32 due to build failures. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.33</version>
+            <version>3.13.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Rollback snowflake driver to 3.13.32 due to build failures. 