### PR TITLE
addDefaultValueBoolean expected sql updated

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSql/db2-luw/addDefaultValueBoolean.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/db2-luw/addDefaultValueBoolean.sql
@@ -1,2 +1,2 @@
-CREATE TABLE "DB2INST1".add_default_value_boolean_test (id INTEGER NOT NULL, boolean_test SMALLINT, CONSTRAINT PK_ADD_DEFAULT_VA PRIMARY KEY (id))
-ALTER TABLE "DB2INST1".add_default_value_boolean_test ALTER COLUMN  boolean_test SET DEFAULT 1
+CREATE TABLE "DB2INST1".add_default_value_boolean_test (id INTEGER NOT NULL, boolean_test BOOLEAN, CONSTRAINT PK_ADD_DEFAULT_VA PRIMARY KEY (id))
+ALTER TABLE "DB2INST1".add_default_value_boolean_test ALTER COLUMN  boolean_test SET DEFAULT TRUE


### PR DESCRIPTION
This change is required since `supportsBooleanDataType()` has been updated in this [PR](https://github.com/liquibase/liquibase/pull/4754).