### PR TITLE
DAT-16122

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,8 @@ jobs:
     name: Setup
     needs: check_build_safety
     runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: {{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
     outputs:
       useLiquibaseSnapshot: ${{ steps.configure-build.outputs.useLiquibaseSnapshot }}
       liquibaseBranch: ${{ steps.configure-build.outputs.liquibaseBranch }}
@@ -86,7 +88,7 @@ jobs:
         id: configure-build
         uses: actions/github-script@v6.4.1
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          github-token: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
           script: |
             const helper = require('./.github/util/workflow-helper.js')({github, context});
 
@@ -134,7 +136,7 @@ jobs:
       - name: Install Snapshot Liquibase
         if: steps.configure-build.outputs.useLiquibaseSnapshot == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
           mvn -B liquibase-sdk:install-snapshot \
@@ -195,7 +197,7 @@ jobs:
       - name: Configure Liquibase Version
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
 
@@ -235,7 +237,7 @@ jobs:
       - name: Update status
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
 


### PR DESCRIPTION
1. **ISSUE**: Dependabot PR's always passed but the user PR's  always failed on "develop" branch
2. using INSTALL_SNAPSHOT_LIQUIBASE instead of BOT_TOKEN. I want to ensure that we refrain from using BOT_TOKEN as we have no idea what is BOT_TOKEN and what permissions it has. 