### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ on:
       liquibaseBranch:
         description: Liquibase branch to pull artifacts from. Leave empty to use latest commit on current branch. For forks, use the `owner:branch` format. Can support a comma separated list of branches to search for
         required: false
+      liquibaseCommit:
+        description: Liquibase commit to pull artifacts from. Leave empty to use "liquibaseBranch" setting.  
+        required: false
       testClasses:
         type: choice
         description: Test Suite or test class to run


### PR DESCRIPTION
Instead of throwing a warning, OSS throws an error when `liquibaseCommit` is not present:

https://github.com/liquibase/liquibase/actions/runs/6630492580/job/18012572453