### PR TITLE
DAT-16486: use run-tests.yml from OSS workflow

### DIFF
--- a/.github/util/workflow-helper.js
+++ b/.github/util/workflow-helper.js
@@ -115,7 +115,7 @@ module.exports = ({github, context}) => {
                             let runs = await github.rest.actions.listWorkflowRuns({
                                 "owner": owner,
                                 "repo": repo,
-                                "workflow_id": "build.yml",
+                                "workflow_id": "run-tests.yml",
                                 "per_page": 100,
                                 "page": pageNumber,
                             });


### PR DESCRIPTION
fix: `.github/util/workflow-helper.js` : the finish step in DAT-16486 is looking at the old `build.yml` file. We need to make sure it takes the run of the new workflow and not the old `build.yml`
Error link : https://github.com/liquibase/liquibase-test-harness/actions/runs/7290781935/job/19868497916#step:4:109