### PR TITLE
Update pom.xml liquibase-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.enforcer.requireJavaVersion>${maven.compiler.source}</maven.enforcer.requireJavaVersion>
-        <liquibase-core.version>[4.22.0,)</liquibase-core.version>
+        <liquibase-core.version>[4.23.0,)</liquibase-core.version>
         <!-- `[X,)` syntax means open-ended version range, version X or higher -->
     </properties>
     <organization>


### PR DESCRIPTION
The accepted range of liquibase-core versions started  at 4.22.0, which is deprecated, so it doesn't make sense to set it there. I'm setting it at 4.23.0