### PR TITLE
Make CockroachDB test be able to run on secure clusters.

### DIFF
--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -322,7 +322,7 @@ services:
     networks:
       - roachnet
     volumes:
-      - ./setup_db.sh:/setup_db.sh
+      - ./setup_db.sh:/setup_db.sh --insecure
     entrypoint: "/bin/bash"
     command: /setup_db.sh crdb-20.2
     depends_on:
@@ -344,7 +344,7 @@ services:
     networks:
       - roachnet
     volumes:
-      - ./setup_db.sh:/setup_db.sh
+      - ./setup_db.sh:/setup_db.sh --insecure
     entrypoint: "/bin/bash"
     command: /setup_db.sh crdb-21.1
     depends_on:
@@ -367,7 +367,7 @@ services:
     networks:
       - roachnet
     volumes:
-      - ./setup_db.sh:/setup_db.sh
+      - ./setup_db.sh:/setup_db.sh --insecure
     entrypoint: "/bin/bash"
     command: /setup_db.sh crdb-21.2
     depends_on:
@@ -390,7 +390,7 @@ services:
     networks:
       - roachnet
     volumes:
-      - ./setup_db.sh:/setup_db.sh
+      - ./setup_db.sh:/setup_db.sh --insecure
     entrypoint: "/bin/bash"
     command: /setup_db.sh crdb-22.1
     depends_on:

--- a/src/test/resources/docker/setup_db.sh
+++ b/src/test/resources/docker/setup_db.sh
@@ -3,8 +3,9 @@
 #sleep 10
 
 HOST=$1
-HOSTPARAMS="--host $HOST --insecure"
-SQL="/cockroach/cockroach.sh sql $HOSTPARAMS"
+ARGS=$2
+HOSTPARAMS="--host $HOST"
+SQL="/cockroach/cockroach.sh sql $HOSTPARAMS $ARGS"
 
 $SQL -e "CREATE DATABASE lbcat;"
 $SQL -e "CREATE USER lbuser;"


### PR DESCRIPTION
The setup script for cockroachdb tests previously passed an --insecure flag. This change replaces that with a more generic ARGS flag that gives more flexibility. The test can still run on insecure clusters if --insecure is passed or on secure clusters if certs-dir is passed.