### PR TITLE
DAT-17264: use build-logic reusable workflow

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -1,0 +1,15 @@
+name: Attach Artifact to Release
+
+on:
+  pull_request:
+    types:
+      - closed
+  push:
+    branches:
+      - main
+
+jobs:
+
+  attach-artifact-to-release:
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.6.5
+    secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -96,30 +96,10 @@ jobs:
           path: |
             target/*.jar
 
-
-  draft-release:
+  create-release:
     needs: [ setup, build ]
-    name: Draft Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: liquibase-test-harness
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          target_commitish: ${{ needs.build.outputs.releaseSha }}
-          name: v${{ needs.setup.outputs.extensionVersion }}
-          tag_name: liquibase-test-harness-${{ needs.setup.outputs.extensionVersion }}
-          draft: true
-          body: In version ${{ needs.setup.outputs.extensionVersion }} we
-          files: liquibase-test-harness-*.jar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.6.5
+    secrets: inherit
 
   bump-pom-to-snapshot:
     name: Prepare POM for Development

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,30 +1,11 @@
 name: Release Extension to Sonatype
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
 jobs:
-    release:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-
-        - name: Set up Java for publishing to Maven Central Repository
-          uses: actions/setup-java@v4
-          with:
-            java-version: '11'
-            distribution: 'temurin'
-            cache: 'maven'
-            server-id: sonatype-nexus-staging
-            server-username: MAVEN_USERNAME
-            server-password: MAVEN_PASSWORD
-            gpg-private-key: ${{ secrets.GPG_SECRET }}
-            gpg-passphrase: GPG_PASSPHRASE
-
-        - name: Publish to the Maven Central Repository
-          run: mvn clean deploy -DskipTests=true -P release-sign-artifacts
-          env:
-            MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-            MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+  release:
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.6.5
+    secrets: inherit


### PR DESCRIPTION
feat: `.github/workflows/create-release.yml`: use `liquibase/build-logic/.github/workflows/create-release.yml` to run Release Drafter to auto create draft release notes

feat: `.github/workflows/release-published.yml`: use `liquibase/build-logic/.github/workflows/extension-release-published.yml` to Publishe a release to Maven Central

feat: `.github/workflows/attach-artifact-release.yml`: use `liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml` to attaches a tested artifact to the draft release.