### PR TITLE
Downgrade MSSQL driver version from 12.7.0.jre11-preview to 12.6.1.jre11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>12.7.0.jre11-preview</version>
+            <version>12.6.1.jre11</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION
 As discussed with the team on [Slack](https://liquibase.slack.com/archives/CK9JJEENB/p1712845031776109), we should keep alignment on driver versions across the projects and not use `preview` versions. So reverting this version upgrade to the previous version.