### PR TITLE
DAT-17492: remove user status check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,14 +265,6 @@ jobs:
           buildOverview="$(mvn -B -q liquibase-sdk:get-build-info '-Dliquibase.sdk.buildInfo.outputKey=overview' '-Dliquibase.sdk.repo=liquibase/liquibase-pro')"
           echo "::notice :: Installed Snapshot Liquibase-pro $buildOverview"
 
-          mvn -B liquibase-sdk:set-commit-status \
-            "-Dliquibase.sdk.repo=${{ steps.configure-build.outputs.liquibaseRepo }}" \
-            "-Dliquibase.sdk.status.context=Run Test Harness" \
-            "-Dliquibase.sdk.status.state=PENDING" \
-            "-Dliquibase.sdk.status.url=https://github.com/liquibase/liquibase-test-harness/actions/runs/${{ github.run_id }}" \
-            "-Dliquibase.sdk.status.description=Internal functional tests" \
-            "-Dliquibase.sdk.status.commit=installed"
-
       - name: Cache installed Liquibase
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
fix: `.github/workflows/main.yml`: we are sending notification at the very end on the Finish job which triggers exactly the same job. 
Removing the previous step which is sending the notification as @user

![Screenshot from 2024-04-17 13-42-25 (1)](https://github.com/liquibase/liquibase-test-harness/assets/76010603/8b60b251-3877-4a80-b8ae-b5d673b84fdb)
