### PR TITLE
🔧 DAT-18287: fix `Bad credentials`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,6 +324,8 @@ jobs:
     name: Finish
     runs-on: ubuntu-22.04
     needs: [ setup, test, authorize ]
+    permissions:
+      contents: write
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
fix: `.github/workflows/main.yml`: This ensures that the BOT_TOKEN has the necessary access for the actions you want to perform.Sometimes, even with a PAT, GitHub might restrict actions for security.

successful run for a dependabot PR :
PR: https://github.com/liquibase/liquibase-test-harness/pull/884
run: https://github.com/liquibase/liquibase-test-harness/actions/runs/10621496852/job/29443823445?pr=884