### PR TITLE
🔧 DAT-18287 statuses: write

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Coordinate Liquibase-Test-Harness
-        uses: actions/github-script@v6.4.1
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -325,6 +325,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      statuses: write
     needs: [ setup, test, authorize ]
     if: ${{ always() }}
     steps:


### PR DESCRIPTION
- fix: `.github/workflows/main.yml` :this will grant the workflow the ability to write contents to the repository and also set commit statuses, which is what the github.rest.repos.createCommitStatus API call does.