### PR TITLE
[DAT-18732] fixed sources and javadoc jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,14 +424,6 @@
                                     <sourceFile>${project.basedir}/pom.xml</sourceFile>
                                     <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
                                 </fileSet>
-                                <fileSet>
-                                    <sourceFile>${project.basedir}/README.md</sourceFile>
-                                    <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}-javadoc.jar</destinationFile>
-                                </fileSet>
-                                <fileSet>
-                                    <sourceFile>${project.basedir}/README.md</sourceFile>
-                                    <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}-sources.jar</destinationFile>
-                                </fileSet>
                             </fileSets>
                         </configuration>
                     </execution>


### PR DESCRIPTION
For open-source repos, like test-harness we don't need to hide javadocs or sources. Vice versa, sources need to be public to conveniently work with test-harness tests in extensions.