### PR TITLE
[DAT-19146] WalMart POC :: Informix :: Test :: Determine status of Informix integration functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
             <version>2.18.0</version>
         </dependency>
         <dependency>
+            <groupId>com.ibm.informix</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>4.50.11</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -160,11 +160,6 @@
             <version>2.18.0</version>
         </dependency>
         <dependency>
-            <groupId>com.ibm.informix</groupId>
-            <artifactId>jdbc</artifactId>
-            <version>4.50.11</version>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.4</version>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/addDefaultValueComputed.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/addDefaultValueComputed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+<!--https://docs.liquibase.com/change-types/add-default-value.html-->
+    <changeSet author="oleh" id="1">
+        <addDefaultValue  tableName="posts"
+                          columnName="inserted_date"
+                          columnDataType="date"
+                          defaultValueComputed="DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/addDefaultValueDate.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/addDefaultValueDate.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="as">
+        <addColumn tableName="authors">
+            <column name="dateTimeColumn" type="datetime"/>
+        </addColumn>
+        <addDefaultValue tableName="authors"
+                         columnName="dateTimeColumn"
+                         columnDataType="datetime"
+                         defaultValueDate="2008-02-12T12:34:03"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/addDefaultValueNumeric.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/addDefaultValueNumeric.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="as">
+        <addColumn tableName="authors">
+            <column name="numericColumn" type="INTEGER"/>
+        </addColumn>
+        <addDefaultValue tableName="authors"
+                         columnName="numericColumn"
+                         columnDataType="INTEGER"
+                         defaultValueNumeric="100000000"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/alterSequence.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/alterSequence.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="as">
+        <createSequence
+                        incrementBy="1"
+                        minValue="1"
+                        sequenceName="test_sequence"
+                        startValue="1"/>
+        <rollback>
+            <dropSequence sequenceName="test_sequence"/>
+        </rollback>
+    </changeSet>
+    <changeSet author="as" id="2" >
+        <alterSequence  cacheSize="371717"
+                        cycle="true"
+                        incrementBy="10"
+                        maxValue="371717"
+                        minValue="1"
+                        sequenceName="test_sequence"/>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createFunction.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createFunction.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="as" id="1">
+        <pro:createFunction
+                encoding="UTF-8"
+                functionName="test_function">CREATE FUNCTION test_function()
+            RETURNS BOOLEAN
+            LANGUAGE SPL
+            BEGIN
+            LET trace_message = 'Test function executed';
+            TRACE trace_message;
+            RETURN TRUE; -- Use TRUE or appropriate value as needed.
+            END;
+        </pro:createFunction>
+        <rollback>
+            <pro:dropFunction functionName="test_function"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createPackage.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createPackage.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet  author="as" id="1">
+        <pro:createPackage encoding="UTF-8"
+                           packageName="Test package">CREATE FUNCTION test_function()
+            RETURNS BOOLEAN
+            LANGUAGE SPL
+            BEGIN
+            LET trace_message = 'Test function executed';
+            TRACE trace_message;
+            RETURN TRUE; -- Use TRUE or appropriate value as needed.
+            END;</pro:createPackage>
+        <rollback>
+            <pro:dropFunction functionName="test_function"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createPackageBody.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createPackageBody.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet  author="as" id="1">
+        <pro:createPackageBody encoding="UTF-8"
+                               packageBodyName="Test package">CREATE FUNCTION test_function()
+            RETURNS BOOLEAN
+            LANGUAGE SPL
+            BEGIN
+            LET trace_message = 'Test function executed';
+            TRACE trace_message;
+            RETURN TRUE; -- Use TRUE or appropriate value as needed.
+            END;</pro:createPackageBody>
+        <rollback>
+            <pro:dropFunction functionName="test_function"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createProcedure.txt
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createProcedure.txt
@@ -1,0 +1,3 @@
+CREATE PROCEDURE test_procedure ( per_cent INT)
+        UPDATE stock SET unit_price = unit_price + (unit_price * (per_cent/100) );
+        END PROCEDURE

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createProcedure.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createProcedure.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+        <!--https://docs.liquibase.com/change-types/create-procedure.html-->
+    <changeSet author="as" id="1">
+        <comment>test procedure</comment>
+        <createProcedure
+                encoding="UTF-8"
+                procedureName="test_procedure">CREATE PROCEDURE test_procedure ( per_cent INT)
+        UPDATE stock SET unit_price = unit_price + (unit_price * (per_cent/100) );
+        END PROCEDURE
+        </createProcedure>
+        <rollback>
+            <dropProcedure procedureName="test_procedure"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createProcedureFromFile.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createProcedureFromFile.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+        <!--https://docs.liquibase.com/change-types/create-procedure.html-->
+    <changeSet author="as" id="1">
+        <comment>test procedure</comment>
+        <createProcedure
+                encoding="UTF-8"
+                path="createProcedure.txt"
+                relativeToChangelogFile="true"
+                procedureName="test_procedure">
+        </createProcedure>
+        <rollback>
+            <dropProcedure procedureName="test_procedure"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createSequence.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createSequence.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="oleh" id="1">
+        <createSequence
+                sequenceName="test_sequence"
+                incrementBy="1"
+                startValue="1"
+                minValue="1"
+        />
+        <rollback>
+            <dropSequence sequenceName="test_sequence"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/createTrigger.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/createTrigger.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="as" id="1">
+        <comment>test procedure</comment>
+        <createProcedure
+                encoding="UTF-8"
+                procedureName="test_function">CREATE FUNCTION test_function()
+            RETURNS BOOLEAN
+            LANGUAGE SPL
+        BEGIN
+    LET trace_message = 'Test function executed';
+    TRACE trace_message;
+        RETURN TRUE;
+        END;
+        </createProcedure>
+        <rollback>
+            <sql>DROP FUNCTION test_function()</sql>
+        </rollback>
+    </changeSet>
+    <changeSet  author="as" id="2">
+        <pro:createTrigger disabled="false"
+                           encoding="UTF-8"
+                           scope="test"
+                           tableName="posts"
+                           triggerName="test_trigger">CREATE TRIGGER test_trigger
+            BEFORE INSERT ON your_table_name
+            FOR EACH ROW
+            EXECUTE FUNCTION test_function();
+        </pro:createTrigger>
+        <rollback>
+            <pro:dropTrigger triggerName="test_trigger"
+                             tableName="posts"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/dropDefaultValue.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/dropDefaultValue.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+<!--https://docs.liquibase.com/change-types/add-default-value.html-->
+        <changeSet author="oleh" id="1">
+            <addDefaultValue  tableName="posts"
+                              columnName="title"
+                              columnDataType="varchar(255)"
+                              defaultValue="title_test"/>
+            <dropDefaultValue tableName="posts" columnName="title" columnDataType="varchar(255)"/>
+            <rollback/>
+        </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/dropProcedure.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/dropProcedure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+        <!--https://docs.liquibase.com/change-types/drop-procedure.html-->
+    <changeSet author="as" id="1">
+        <comment>test procedure</comment>
+        <createProcedure
+                        encoding="UTF-8"
+                        path="createProcedure.txt"
+                        relativeToChangelogFile="true"
+                        procedureName="test_procedure">
+        </createProcedure>
+        <dropProcedure procedureName="test_procedure"/>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/dropSequence.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/dropSequence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="oleh" id="1">
+        <createSequence
+                sequenceName="test_sequence"
+                incrementBy="1"
+                startValue="1"
+                minValue="1"
+        />
+        <dropSequence sequenceName="test_sequence"/>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/changelogs/informix/dropTrigger.xml
+++ b/src/main/resources/liquibase/harness/change/changelogs/informix/dropTrigger.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="as" id="1">
+        <comment>test procedure</comment>
+        <createProcedure
+                encoding="UTF-8"
+                procedureName="test_function">CREATE FUNCTION test_function()
+            RETURNS BOOLEAN
+            LANGUAGE SPL
+        BEGIN
+    LET trace_message = 'Test function executed';
+    TRACE trace_message;
+        RETURN TRUE;
+        END;
+        </createProcedure>
+        <rollback>
+            <sql>DROP FUNCTION test_function()</sql>
+        </rollback>
+    </changeSet>
+    <changeSet  author="as" id="2">
+        <pro:createTrigger disabled="false"
+                           encoding="UTF-8"
+                           scope="test"
+                           tableName="posts"
+                           triggerName="test_trigger">CREATE TRIGGER test_trigger
+            BEFORE INSERT ON your_table_name
+            FOR EACH ROW
+            EXECUTE FUNCTION test_function();
+        </pro:createTrigger>
+        <rollback/>
+    </changeSet>
+    <changeSet author="as" id="3">
+        <pro:dropTrigger triggerName="test_trigger"
+                         tableName="posts"/>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/addDefaultValue.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/addDefaultValue.json
@@ -1,0 +1,15 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "defaultValue": "title_test",
+            "name": "title",
+            "nullable": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/addDefaultValueBoolean.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/addDefaultValueBoolean.json
@@ -1,0 +1,15 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "defaultValue": "T\\!\\{liquibase.statement.DatabaseFunction\\}",
+            "name": "booleancolumn",
+            "nullable": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/addDefaultValueNumeric.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/addDefaultValueNumeric.json
@@ -1,0 +1,15 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "defaultValue": "100000000\\!\\{java.lang.Integer\\}",
+            "name": "numericColumn",
+            "nullable": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/alterSequence.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/alterSequence.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Sequence": [
+        {
+          "sequence": {
+            "name": "test_sequence"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/createTableTimestamp.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/createTableTimestamp.json
@@ -1,0 +1,28 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "lms_create_table_test"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "lms_test_id"
+          }
+        },
+        {
+          "column": {
+            "name": "lms_test_timestamp",
+            "type": {
+              "typeName": "datetime year to fraction(5)"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/createView.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/createView.json
@@ -1,0 +1,13 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.View": [
+        {
+          "view": {
+            "definition": "select x0.id, x0.first_name, x0.last_name, x0.email from (select x1.id, x1.first_name, x1.last_name, x1.email from authors x1 ) x0(id, first_name, last_name, email)",
+            "name": "test_view"
+          }
+        }]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/dropDefaultValue.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/informix/dropDefaultValue.json
@@ -1,0 +1,17 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "title",
+            "nullable": true,
+            "type": {
+              "typeName": "varchar"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/addCheckConstraint.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/addCheckConstraint.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:addCheckConstraint' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/addDefaultValueComputed.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/addDefaultValueComputed.sql
@@ -1,0 +1,9 @@
+INVALID TEST
+
+-- Bug on Liquibase side: incorrect generated sql
+-- Actual:
+-- ALTER TABLE testdb:informix.posts
+--     MODIFY (inserted_date date DEFAULT DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5));
+-- Expected:
+-- ALTER TABLE testdb:informix.posts
+--     MODIFY (inserted_date DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5));

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/addDefaultValueDate.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/addDefaultValueDate.sql
@@ -1,0 +1,4 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Incorrect SQL generated on rollback defaultValueDate
+        --[Failed SQL: (-201) ALTER TABLE testdb:informix.authors MODIFY (dateTimeColumn datetime)]

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/addDefaultValueSequenceNext.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/addDefaultValueSequenceNext.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support using a sequence’s NEXTVAL directly in a DEFAULT clause

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/addUniqueConstraint.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/addUniqueConstraint.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Missing UniqueConstraints in Liquibase Snapshot output

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/createFunction.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/createFunction.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createFunction' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/createPackage.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/createPackage.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support packages

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/createPackageBody.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/createPackageBody.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support package bodies

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/createProcedure.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/createProcedure.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Missing Procedures in Liquibase Snapshot output

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/createProcedureFromFile.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/createProcedureFromFile.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Missing Procedures in Liquibase Snapshot output

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/createTrigger.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/createTrigger.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createTrigger' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/disableCheckConstraint.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/disableCheckConstraint.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:addCheckConstraint' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/disableTrigger.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/disableTrigger.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createTrigger' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/dropCheckConstraint.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/dropCheckConstraint.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:addCheckConstraint' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/dropFunction.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/dropFunction.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createFunction' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/dropTrigger.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/dropTrigger.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createTrigger' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/enableCheckConstraint.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/enableCheckConstraint.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:addCheckConstraint' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/enableTrigger.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/enableTrigger.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createTrigger' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/renameSequence.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/renameSequence.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support renameSequence

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/renameTrigger.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/renameTrigger.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Bug on Liquibase side: Change Type 'pro:createTrigger' is not allowed for Informix Dynamic Server

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/renameView.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/renameView.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support renameView

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/setColumnRemarks.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/setColumnRemarks.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support setColumnRemarks

--- a/src/main/resources/liquibase/harness/change/expectedSql/informix/setTableRemarks.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/informix/setTableRemarks.sql
@@ -1,0 +1,3 @@
+INVALID TEST
+
+-- Informix does not support setTableRemarks

--- a/src/main/resources/liquibase/harness/data/changelogs/informix/loadUpdateData.csv
+++ b/src/main/resources/liquibase/harness/data/changelogs/informix/loadUpdateData.csv
@@ -1,0 +1,4 @@
+id;first_name;last_name;email;birthdate;added
+1;Adam;Gods;test1@example.com;1000-02-27;2000-02-04T02:32:00
+7;Noah;Lamekhs;test2@example.com;2000-02-27;1994-12-10T01:00:00
+8;Muhammad;Ibn Abdullah;test3@example.com;3000-02-27;2000-12-10T01:00:00

--- a/src/main/resources/liquibase/harness/data/changelogs/informix/loadUpdateData.xml
+++ b/src/main/resources/liquibase/harness/data/changelogs/informix/loadUpdateData.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="as">
+        <loadUpdateData file="loadUpdateData.csv"
+                        relativeToChangelogFile="true"
+                        quotchar="'"
+                        separator=";"
+                        tableName="authors"
+                        primaryKey="id">
+        </loadUpdateData>
+        <rollback>
+            <sql splitStatements="true">
+                DELETE FROM authors WHERE id = 1;
+                INSERT INTO authors (id, first_name, last_name, email, birthdate, added) VALUES (1, 'Eileen', 'Lubowitz', 'ppaucek@example.org', TO_DATE('1991-03-04', '%Y-%m-%d'), TO_DATE('2004-05-30 02:08:25', '%Y-%m-%d %H:%M:%S'));;
+                DELETE FROM authors WHERE id = 7;
+                DELETE FROM authors WHERE id = 8;
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -354,7 +354,7 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/docker-entrypoint-initdb.d/informix-init.sql"
+      - "./informix-init.sql:/opt/ibm/data/sch_init_informix.custom.sql"
 
   informix-14.10:
     image: icr.io/informix/informix-developer-database:14.10.FC7W1DE
@@ -368,7 +368,7 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/docker-entrypoint-initdb.d/informix-init.sql"
+      - "./informix-init.sql:/opt/ibm/data/sch_init_informix.custom.sql"
 
 
 # Titan (https://titan-data.io) is managing these images for our CI/CD process. If you want to run them locally you'll have to

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -350,6 +350,7 @@ services:
       - "9088:9088"
     environment:
       LICENSE: "accept"
+      INIT_FILE: "sch_init_informix.custom.sql"
       SIZE: "custom"
     restart: always
     privileged: true

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -354,7 +354,7 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/opt/ibm/data/sch_init_informix.custom.sql"
+      - "./informix-init.sql:/docker-entrypoint-initdb.d/informix-init.sql"
 
   informix-14.10:
     image: icr.io/informix/informix-developer-database:14.10.FC7W1DE
@@ -368,7 +368,8 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/opt/ibm/config/informix-init.sql"
+      - "./informix-init.sql:/docker-entrypoint-initdb.d/informix-init.sql"
+
 
 # Titan (https://titan-data.io) is managing these images for our CI/CD process. If you want to run them locally you'll have to
 #  populate init script (hsqldb-init.sql) for this platform manually or install titan and pull image pre-populated with data

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -354,7 +354,7 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/opt/ibm/config/informix-init.sql"
+      - "./informix-init.sql:/opt/ibm/data/sch_init_informix.custom.sql"
 
   informix-14.10:
     image: icr.io/informix/informix-developer-database:14.10.FC7W1DE
@@ -369,7 +369,7 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/opt/ibm/data/sch_init_informix.custom.sql"
+      - "./informix-init.sql:/opt/ibm/config/informix-init.sql"
 
 
 # Titan (https://titan-data.io) is managing these images for our CI/CD process. If you want to run them locally you'll have to

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -354,7 +354,7 @@ services:
     restart: always
     privileged: true
     volumes:
-      - "./informix-init.sql:/opt/ibm/data/sch_init_informix.custom.sql"
+      - "./informix-init.sql:/opt/ibm/config/informix-init.sql"
 
   informix-14.10:
     image: icr.io/informix/informix-developer-database:14.10.FC7W1DE

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -1,7 +1,8 @@
 CREATE DATABASE testdb WITH LOG MODE ANSI;
+DATABASE testdb;
 
-DROP TABLE IF EXISTS authors;
-CREATE TABLE authors (
+DROP TABLE IF EXISTS testdb:informix.authors;
+CREATE TABLE testdb:informix.authors (
                          id SERIAL PRIMARY KEY,
                          first_name VARCHAR(50) NOT NULL,
                          last_name VARCHAR(50) NOT NULL,
@@ -10,29 +11,29 @@ CREATE TABLE authors (
                          added DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5)
 );
 
-INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+INSERT INTO testdb:informix.authors (id, first_name, last_name, email, birthdate, added)
 VALUES
     (1, 'Eileen', 'Lubowitz', 'ppaucek@example.org', '1991-03-04', '2004-05-30 02:08:25');
 
-INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+INSERT INTO testdb:informix.authors (id, first_name, last_name, email, birthdate, added)
 VALUES
     (2, 'Tamia', 'Mayert', 'shansen@example.org', '2016-03-27', '2014-03-21 02:52:00');
 
-INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+INSERT INTO testdb:informix.authors (id, first_name, last_name, email, birthdate, added)
 VALUES
     (3, 'Cyril', 'Funk', 'reynolds.godfrey@example.com', '1988-04-21', '2011-06-24 18:17:48');
 
-INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+INSERT INTO testdb:informix.authors (id, first_name, last_name, email, birthdate, added)
 VALUES
     (4, 'Nicolas', 'Buckridge', 'xhoeger@example.net', '2017-02-03', '2019-04-22 02:04:41');
 
-INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+INSERT INTO testdb:informix.authors (id, first_name, last_name, email, birthdate, added)
 VALUES
     (5, 'Jayden', 'Walter', 'lillian66@example.com', '2010-02-27', '1990-02-04 02:32:00');
 
 
-DROP TABLE IF EXISTS posts;
-CREATE TABLE posts (
+DROP TABLE IF EXISTS testdb:informix.posts;
+CREATE TABLE testdb:informix.posts (
                        id SERIAL,
                        author_id INT NOT NULL,
                        title VARCHAR(255) NOT NULL,
@@ -41,17 +42,20 @@ CREATE TABLE posts (
                        inserted_date DATE
 );
 
-INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+ALTER TABLE testdb:informix.posts MODIFY (title VARCHAR(255) DEFAULT 'title_test');
+
+
+INSERT INTO testdb:informix.posts (id, author_id, title, description, content, inserted_date)
 VALUES  (1,1,'temporibus','voluptatum','Fugit non et doloribus repudiandae.','2015-11-18');
 
-INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+INSERT INTO testdb:informix.posts (id, author_id, title, description, content, inserted_date)
 VALUES  (2,2,'ea','aut','Tempora molestias maiores provident molestiae sint possimus quasi.','1975-06-08');
 
-INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+INSERT INTO testdb:informix.posts (id, author_id, title, description, content, inserted_date)
 VALUES  (3,3,'illum','rerum','Delectus recusandae sit officiis dolor.','1975-02-25');
 
-INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+INSERT INTO testdb:informix.posts (id, author_id, title, description, content, inserted_date)
 VALUES  (4,4,'itaque','deleniti','Magni nam optio id recusandae.','2010-07-28');
 
-INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+INSERT INTO testdb:informix.posts (id, author_id, title, description, content, inserted_date)
 VALUES  (5,5,'ad','similique','Rerum tempore quis ut nesciunt qui excepturi est.','2006-10-09');

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -1,1 +1,60 @@
 CREATE DATABASE testdb WITH LOG MODE ANSI;
+
+DROP TABLE IF EXISTS authors;
+CREATE TABLE authors (
+                         id SERIAL PRIMARY KEY,
+                         first_name VARCHAR(50) NOT NULL,
+                         last_name VARCHAR(50) NOT NULL,
+                         email VARCHAR(100) NOT NULL,
+                         birthdate DATE NOT NULL,
+                         added DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5)
+);
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (1, 'Eileen', 'Lubowitz', 'ppaucek@example.org', '1991-03-04', '2004-05-30 02:08:25');
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (2, 'Tamia', 'Mayert', 'shansen@example.org', '2016-03-27', '2014-03-21 02:52:00');
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (3, 'Cyril', 'Funk', 'reynolds.godfrey@example.com', '1988-04-21', '2011-06-24 18:17:48');
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (4, 'Nicolas', 'Buckridge', 'xhoeger@example.net', '2017-02-03', '2019-04-22 02:04:41');
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (5, 'Jayden', 'Walter', 'lillian66@example.com', '2010-02-27', '1990-02-04 02:32:00');
+
+
+DROP TABLE IF EXISTS posts;
+CREATE TABLE posts (
+                       id SERIAL,
+                       author_id INT NOT NULL,
+                       title VARCHAR(255) NOT NULL,
+                       description VARCHAR(255) NOT NULL,
+                       content VARCHAR(255) NOT NULL,
+                       inserted_date DATE
+);
+
+ALTER TABLE testdb:informix.posts MODIFY (title VARCHAR(255) DEFAULT 'title_test');
+
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES  (1,1,'temporibus','voluptatum','Fugit non et doloribus repudiandae.','2015-11-18');
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES  (2,2,'ea','aut','Tempora molestias maiores provident molestiae sint possimus quasi.','1975-06-08');
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES  (3,3,'illum','rerum','Delectus recusandae sit officiis dolor.','1975-02-25');
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES  (4,4,'itaque','deleniti','Magni nam optio id recusandae.','2010-07-28');
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES  (5,5,'ad','similique','Rerum tempore quis ut nesciunt qui excepturi est.','2006-10-09');

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -55,7 +55,7 @@ BEGIN WORK;
 -- Drop and create posts table
 DROP TABLE IF EXISTS posts;
 CREATE TABLE posts (
-                       id SERIAL PRIMARY KEY,
+                       id SERIAL,
                        author_id INT NOT NULL,
                        title VARCHAR(255) NOT NULL DEFAULT 'title_test',
                        description VARCHAR(255) NOT NULL,

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -8,7 +8,7 @@ BEGIN WORK;
 -- Drop and create authors table
 DROP TABLE IF EXISTS authors;
 CREATE TABLE authors (
-                         id SERIAL PRIMARY KEY,
+                         id SERIAL,
                          first_name VARCHAR(50) NOT NULL,
                          last_name VARCHAR(50) NOT NULL,
                          email VARCHAR(100) NOT NULL,
@@ -55,7 +55,7 @@ BEGIN WORK;
 -- Drop and create posts table
 DROP TABLE IF EXISTS posts;
 CREATE TABLE posts (
-                       id SERIAL PRIMARY KEY,
+                       id SERIAL,
                        author_id INT NOT NULL,
                        title VARCHAR(255) NOT NULL DEFAULT 'title_test',
                        description VARCHAR(255) NOT NULL,

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -1,59 +1,93 @@
 CREATE DATABASE testdb WITH LOG MODE ANSI;
 
+DATABASE testdb;
+
 -- Use BEGIN WORK to start a transaction
 BEGIN WORK;
 
 -- Drop and create authors table
-DROP TABLE IF EXISTS informix.authors;
-CREATE TABLE informix.authors (
-                                  id SERIAL PRIMARY KEY,
-                                  first_name VARCHAR(50) NOT NULL,
-                                  last_name VARCHAR(50) NOT NULL,
-                                  email VARCHAR(100) NOT NULL,
-                                  birthdate DATE NOT NULL,
-                                  added DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5)
+DROP TABLE IF EXISTS authors;
+CREATE TABLE authors (
+                         id SERIAL PRIMARY KEY,
+                         first_name VARCHAR(50) NOT NULL,
+                         last_name VARCHAR(50) NOT NULL,
+                         email VARCHAR(100) NOT NULL,
+                         birthdate DATE NOT NULL,
+                         added DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5)
 );
 
 -- Insert data into authors table
-INSERT INTO informix.authors (id, first_name, last_name, email, birthdate, added)
-VALUES (1, 'Eileen', 'Lubowitz', 'ppaucek@example.org', DATE('1991-03-04'), '2004-05-30 02:08:25');
-INSERT INTO informix.authors (id, first_name, last_name, email, birthdate, added)
-VALUES (2, 'Tamia', 'Mayert', 'shansen@example.org', DATE('2016-03-27'), '2014-03-21 02:52:00');
-INSERT INTO informix.authors (id, first_name, last_name, email, birthdate, added)
-VALUES (3, 'Cyril', 'Funk', 'reynolds.godfrey@example.com', DATE('1988-04-21'), '2011-06-24 18:17:48');
-INSERT INTO informix.authors (id, first_name, last_name, email, birthdate, added)
-VALUES (4, 'Nicolas', 'Buckridge', 'xhoeger@example.net', DATE('2017-02-03'), '2019-04-22 02:04:41');
-INSERT INTO informix.authors (id, first_name, last_name, email, birthdate, added)
-VALUES (5, 'Jayden', 'Walter', 'lillian66@example.com', DATE('2010-02-27'), '1990-02-04 02:32:00');
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (1, 'Eileen', 'Lubowitz', 'ppaucek@example.org',
+     TO_DATE('1991-03-04', '%Y-%m-%d'),
+     TO_DATE('2004-05-30 02:08:25', '%Y-%m-%d %H:%M:%S'));
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (2, 'Tamia', 'Mayert', 'shansen@example.org',
+     TO_DATE('2016-03-27', '%Y-%m-%d'),
+     TO_DATE('2014-03-21 02:52:00', '%Y-%m-%d %H:%M:%S'));
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (3, 'Cyril', 'Funk', 'reynolds.godfrey@example.com',
+     TO_DATE('1988-04-21', '%Y-%m-%d'),
+     TO_DATE('2011-06-24 18:17:48', '%Y-%m-%d %H:%M:%S'));
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (4, 'Nicolas', 'Buckridge', 'xhoeger@example.net',
+     TO_DATE('2017-02-03', '%Y-%m-%d'),
+     TO_DATE('2019-04-22 02:04:41', '%Y-%m-%d %H:%M:%S'));
+
+INSERT INTO authors (id, first_name, last_name, email, birthdate, added)
+VALUES
+    (5, 'Jayden', 'Walter', 'lillian66@example.com',
+     TO_DATE('2010-02-27', '%Y-%m-%d'),
+     TO_DATE('1990-02-04 02:32:00', '%Y-%m-%d %H:%M:%S'));
 
 -- Commit the transaction for authors table
 COMMIT WORK;
 
--- Start a new transaction
+-- Start a new transaction for the posts table
 BEGIN WORK;
 
 -- Drop and create posts table
-DROP TABLE IF EXISTS informix.posts;
-CREATE TABLE informix.posts (
-                                id SERIAL,
-                                author_id INT NOT NULL,
-                                title VARCHAR(255) NOT NULL DEFAULT 'title_test',
-                                description VARCHAR(255) NOT NULL,
-                                content VARCHAR(255) NOT NULL,
-                                inserted_date DATE
+DROP TABLE IF EXISTS posts;
+CREATE TABLE posts (
+                       id SERIAL PRIMARY KEY,
+                       author_id INT NOT NULL,
+                       title VARCHAR(255) NOT NULL DEFAULT 'title_test',
+                       description VARCHAR(255) NOT NULL,
+                       content VARCHAR(255) NOT NULL,
+                       inserted_date DATE NOT NULL
 );
 
 -- Insert data into posts table
-INSERT INTO informix.posts (id, author_id, title, description, content, inserted_date)
-VALUES (1, 1, 'temporibus', 'voluptatum', 'Fugit non et doloribus repudiandae.', DATE('2015-11-18'));
-INSERT INTO informix.posts (id, author_id, title, description, content, inserted_date)
-VALUES (2, 2, 'ea', 'aut', 'Tempora molestias maiores provident molestiae sint possimus quasi.', DATE('1975-06-08'));
-INSERT INTO informix.posts (id, author_id, title, description, content, inserted_date)
-VALUES (3, 3, 'illum', 'rerum', 'Delectus recusandae sit officiis dolor.', DATE('1975-02-25'));
-INSERT INTO informix.posts (id, author_id, title, description, content, inserted_date)
-VALUES (4, 4, 'itaque', 'deleniti', 'Magni nam optio id recusandae.', DATE('2010-07-28'));
-INSERT INTO informix.posts (id, author_id, title, description, content, inserted_date)
-VALUES (5, 5, 'ad', 'similique', 'Rerum tempore quis ut nesciunt qui excepturi est.', DATE('2006-10-09'));
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES
+    (1, 1, 'temporibus', 'voluptatum', 'Fugit non et doloribus repudiandae.',
+     TO_DATE('2015-11-18', '%Y-%m-%d'));
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES
+    (2, 2, 'ea', 'aut', 'Tempora molestias maiores provident molestiae sint possimus quasi.',
+     TO_DATE('1975-06-08', '%Y-%m-%d'));
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES
+    (3, 3, 'illum', 'rerum', 'Delectus recusandae sit officiis dolor.',
+     TO_DATE('1975-02-25', '%Y-%m-%d'));
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES
+    (4, 4, 'itaque', 'deleniti', 'Magni nam optio id recusandae.',
+     TO_DATE('2010-07-28', '%Y-%m-%d'));
+
+INSERT INTO posts (id, author_id, title, description, content, inserted_date)
+VALUES
+    (5, 5, 'ad', 'similique', 'Rerum tempore quis ut nesciunt qui excepturi est.',
+     TO_DATE('2006-10-09', '%Y-%m-%d'));
 
 -- Commit the transaction for posts table
 COMMIT WORK;

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -41,9 +41,6 @@ CREATE TABLE posts (
                        inserted_date DATE
 );
 
-ALTER TABLE testdb:informix.posts MODIFY (title VARCHAR(255) DEFAULT 'title_test');
-
-
 INSERT INTO posts (id, author_id, title, description, content, inserted_date)
 VALUES  (1,1,'temporibus','voluptatum','Fugit non et doloribus repudiandae.','2015-11-18');
 

--- a/src/test/resources/docker/informix-init.sql
+++ b/src/test/resources/docker/informix-init.sql
@@ -8,7 +8,7 @@ BEGIN WORK;
 -- Drop and create authors table
 DROP TABLE IF EXISTS authors;
 CREATE TABLE authors (
-                         id SERIAL,
+                         id SERIAL PRIMARY KEY,
                          first_name VARCHAR(50) NOT NULL,
                          last_name VARCHAR(50) NOT NULL,
                          email VARCHAR(100) NOT NULL,
@@ -55,7 +55,7 @@ BEGIN WORK;
 -- Drop and create posts table
 DROP TABLE IF EXISTS posts;
 CREATE TABLE posts (
-                       id SERIAL,
+                       id SERIAL PRIMARY KEY,
                        author_id INT NOT NULL,
                        title VARCHAR(255) NOT NULL DEFAULT 'title_test',
                        description VARCHAR(255) NOT NULL,

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -2,13 +2,6 @@ inputFormat: xml
 context: testContext
 
 databasesUnderTest:
-  - name: informix
-    prefix: docker
-    version: 14
-    url: jdbc:informix-sqli://localhost:9088/testdb:INFORMIXSERVER=informix;
-    username: informix
-    password: in4mix
-
   - name: postgresql
     prefix: docker
     version: 16

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -2,6 +2,13 @@ inputFormat: xml
 context: testContext
 
 databasesUnderTest:
+  - name: informix
+    prefix: docker
+    version: 14
+    url: jdbc:informix-sqli://localhost:9088/testdb:INFORMIXSERVER=informix;
+    username: informix
+    password: in4mix
+
   - name: postgresql
     prefix: docker
     version: 16


### PR DESCRIPTION
1. 
_//not expected_
Change Type 'pro:addCheckConstraint' is not allowed for Informix Dynamic Server.
Change Type 'pro:createFunction' is not allowed for Informix Dynamic Server.
Change Type 'pro:createTrigger' is not allowed for Informix Dynamic Server.
_//expected_
Change Type 'pro:createPackage' is not allowed without a valid Liquibase Pro License.
Change Type 'pro:createPackageBody' is not allowed without a valid Liquibase Pro License.


2. 
```
<changeSet author="oleh" id="1">
        <addDefaultValue  tableName="posts"
                          columnName="inserted_date"
                          columnDataType="date"
                          defaultValueComputed="DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5)"/>
    </changeSet>
```

Does not work:
Actual: 
ALTER TABLE testdb:informix.posts
    MODIFY (inserted_date date DEFAULT DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5));
Expected:
ALTER TABLE testdb:informix.posts
    MODIFY (inserted_date DATETIME YEAR TO FRACTION(5) DEFAULT CURRENT YEAR TO FRACTION(5));

  3. Snapshots does not output UniqueConstraint

  4. Cannot add valid procedure into test-harness framework