### PR TITLE
Fix null exception when running test as a dependency

### DIFF
--- a/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTest.groovy
+++ b/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTest.groovy
@@ -63,8 +63,7 @@ class FoundationalTest extends Specification {
         and: "fail test if expectedResultSet is not provided"
         shouldRunChangeSet = expectedResultSet != null
         assert shouldRunChangeSet: "No expectedResultSet for ${testInput.change} against " +
-                "${testInput.database.shortName} ${testInput.database.databaseMajorVersion}." +
-                "${testInput.database.databaseMinorVersion}"
+                "${testInput.databaseName} ${testInput.version}."
 
         and: "check database under test is online"
         def connection = testInput.database.getConnection()


### PR DESCRIPTION
This PR addresses a null exception issue in the Foundation test when it is executed as a dependency. The fix ensures that:

An exception occurs during the execution of the Foundation test because the connection to the database may not be properly established.

