### PR TITLE
[DAT-18428] GCP MSSQL :: SPIKE: determine why test-harness tests for GCP MSSQL are periodically failing during the  drop-all command execution.

### DIFF
--- a/src/test/resources/init-changelogs/gcp/mssql.sql
+++ b/src/test/resources/init-changelogs/gcp/mssql.sql
@@ -13,6 +13,8 @@ BEGIN
     EXEC sp_addrolemember 'db_owner', 'lbuser';
 END
 
+ALTER USER lbuser WITH DEFAULT_SCHEMA = lbuser;
+
 --changeset liquibase:2 runAlways:true
 DROP TABLE IF EXISTS [lbuser].[authors]
 


### PR DESCRIPTION
If this will not help, need to test adding LIQUIBASE_LIQUIBASE_SCHEMA_NAME to env var for gcp_mssql

https://github.com/liquibase/liquibase-test-harness/actions/runs/12394911484/job/34599452458 tests passed