### PR TITLE
DAT-18731 - Resolving the /null problem when not finding the createTable.sql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,19 +344,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
                 <executions>
@@ -467,11 +454,8 @@
         <profile>
             <!-- Required for deployment to Sonatype -->
             <id>release</id>
-            <activation>
-                <property>
-                    <name>env.CI</name>
-                    <value>true</value>
-                </property>
+	    <activation>
+		    <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
                 <executions>
@@ -454,8 +467,11 @@
         <profile>
             <!-- Required for deployment to Sonatype -->
             <id>release</id>
-	    <activation>
-		    <activeByDefault>true</activeByDefault>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                    <value>true</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/src/main/groovy/liquibase/harness/generateChangelog/GenerateChangelogTest.groovy
+++ b/src/main/groovy/liquibase/harness/generateChangelog/GenerateChangelogTest.groovy
@@ -66,12 +66,13 @@ class GenerateChangelogTest extends Specification {
             when: "execute generateChangelog command using different changelog formats"
             argsMap.put("changeLogFile", testInput.xmlChangelogPath)
             executeCommandScope("update", argsMap)
-            argsMap.put("changeLogFile", resourcesDirFullPath + entry.value)
             argsMap.put("excludeObjects", "(?i)posts, (?i)authors")//excluding static test-harness objects from generated changelog
             if (entry.key.equalsIgnoreCase("expectedSqlChangelog")) {
                 def shortDbName = getShortDatabaseName(testInput.databaseName)
                 sqlSpecificChangelogFile = entry.value.replace(".sql", ".$shortDbName" + ".sql")
-                argsMap.put("changeLogFile", resourcesDirFullPath + sqlSpecificChangelogFile)
+                argsMap.put("changeLogFile", resourcesDirFullPath + "generated/" + sqlSpecificChangelogFile)
+            } else {
+                argsMap.put("changeLogFile", resourcesDirFullPath + "generated/" + entry.value)
             }
             executeCommandScope("generateChangelog", argsMap, testInput.databaseName)
 
@@ -128,9 +129,9 @@ class GenerateChangelogTest extends Specification {
         }
         for (Map.Entry<String, String> entry : map.entrySet()) {
             if (entry.key.equalsIgnoreCase("expectedSqlChangelog")) {
-                deleteFile(resourcesDirFullPath + sqlSpecificChangelogFile)
+                deleteFile(resourcesDirFullPath + "generated/" + sqlSpecificChangelogFile)
             } else {
-                deleteFile(resourcesDirFullPath + entry.value)
+                deleteFile(resourcesDirFullPath + "generated/" + entry.value)
             }
         }
 


### PR DESCRIPTION
## Problem:
The system was encountering a `/null` path issue when attempting to locate the createTable.sql file, affecting the test reliability.

## Solution
- Modified the cleanup mechanism in `GenerateChangelogTest` to correctly target and remove generated files in the `src/test/resources/generated/` directory
- Implemented a pre-test cleanup routine to ensure a clean state before test execution
- Fixed the path resolution logic for SQL file lookup

## Evidence
The test execution now shows successful cleanup operations:

<img width="999" alt="image" src="https://github.com/user-attachments/assets/05f4fca7-3f14-4a02-9021-fee68841f386" />
