### PR TITLE
DAT-19350   configure test-harness to deploy master-snapshot to GPM

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,0 +1,32 @@
+name: Deploy Master Snapshot
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+          server-id: github
+          server-username: liquibot
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update version to master-SNAPSHOT
+        run: mvn versions:set -DnewVersion=master-SNAPSHOT
+
+      - name: Build and deploy snapshot
+        run: mvn deploy -P release -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -458,14 +458,14 @@
     </build>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/liquibase/liquibase-test-harness</url>
         </repository>
         <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>github</id>
+            <name>GitHub Packages Snapshots</name>
+            <url>https://maven.pkg.github.com/liquibase/liquibase-test-harness</url>
         </snapshotRepository>
     </distributionManagement>
     <profiles>


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying master snapshots and updates the Maven configuration to use GitHub Packages instead of Sonatype Nexus. The most important changes are summarized below:

### New GitHub Actions Workflow:

* [`.github/workflows/deploy-snapshot.yml`](diffhunk://#diff-90d663ded563f94b4a2d1759ad49ac0408ad22970424654ebe25494646a9d364R1-R32): Added a new workflow named "Deploy Master Snapshot" that triggers on pushes to the `main` branch. This workflow checks out the code, sets up JDK 17, updates the version to `master-SNAPSHOT`, and builds and deploys the snapshot to GitHub Packages.

### Maven Configuration Update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L461-R468): Updated the `distributionManagement` section to replace Sonatype Nexus repositories with GitHub Packages for both release and snapshot repositories.