### PR TITLE
DAT-19303 DevOps :: TiDB :: Add ability to run custom SQL script that creates tables and table data against created db

### DIFF
--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.3'
+version: "3.3"
 
 services:
-
   mysql-5.6:
     platform: linux/x86_64
     image: library/mysql:5.6
@@ -42,22 +41,7 @@ services:
       MYSQL_USER: lbuser
       MYSQL_PASSWORD: LiquibasePass1
     volumes:
-    - "./mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql"
-
-  mysql-8.4:
-    platform: linux/x86_64
-    image: mysql:8.4
-    ports:
-      - "33065:3306"
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: LbRootPass1
-      MYSQL_DATABASE: lbcat
-      MYSQL_USER: lbuser
-      MYSQL_PASSWORD: LiquibasePass1
-    volumes:
       - "./mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql"
-
 
   percona-xtradb-cluster-5.7:
     image: percona/percona-xtradb-cluster:5.7
@@ -155,17 +139,6 @@ services:
     image: postgres:16
     ports:
       - "5440:5432"
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: LbRootPass1
-      POSTGRES_DB: lbcat
-    volumes:
-      - "./postgres-init.sh:/docker-entrypoint-initdb.d/postgres-init.sh"
-
-  postgres-17:
-    image: postgres:17
-    ports:
-      - "5441:5432"
     restart: always
     environment:
       POSTGRES_PASSWORD: LbRootPass1
@@ -311,7 +284,7 @@ services:
   db2-luw:
     image: taskana/db2:11.5
     environment:
-      LICENSE: 'accept'
+      LICENSE: "accept"
     ports:
       - "50000:50000"
 
@@ -414,6 +387,29 @@ services:
     volumes:
       - "./informix-init.sql:/opt/ibm/config/informix-init.sql"
 
+  ti-db:
+    image: pingcap/tidb
+    container_name: ti-db
+    ports:
+      - 4000:4000
+    volumes:
+      - ./storage/tidb:/var/lib/mysql
+
+  ti-db-mysql:
+    image: mysql:latest
+    container_name: mysql-client
+    depends_on:
+      - ti-db
+    volumes:
+      - ./tidb-init.sql:/tidb-init.sql
+    entrypoint: sh -c "
+      echo 'Waiting for TiDB to be ready...' &&
+      sleep 5;
+      echo 'TiDB is ready. Running initialization script...' &&
+      mysql -h ti-db -P 4000 -u root < /tidb-init.sql &&
+      echo 'Initialization complete.' &&
+      tail -f /dev/null" Keeps the container running for interactive use
+    network_mode: "service:ti-db"
 
 # Titan (https://titan-data.io) is managing these images for our CI/CD process. If you want to run them locally you'll have to
 #  populate init script (hsqldb-init.sql) for this platform manually or install titan and pull image pre-populated with data


### PR DESCRIPTION
This pull request includes several changes to the `docker-compose.yml` file in the `src/test/resources/docker` directory. The changes involve updating the version format, removing unused services, and adding new services.

Key changes include:

* **Version Format Update:**
  * Changed the version format from single quotes to double quotes (`version: "3.3"`).

* **Service Removal:**
  * Removed the `mysql-8.4` service, including its configuration and environment variables.
  * Removed the `postgres-17` service, including its configuration and environment variables.

* **Service Addition:**
  * Added the `ti-db` service with the `pingcap/tidb` image and relevant port and volume configurations.
  * Added the `ti-db-mysql` service with the `mysql:latest` image, which depends on the `ti-db` service and includes an initialization script.

* **Minor Format Change:**
  * Changed the license acceptance format from single quotes to double quotes for the `db2-luw` service (`LICENSE: "accept"`).