### PR TITLE
DAT-19772 : Remove Azure PostgreSQL references 

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -22,14 +22,14 @@ on:
       databases:
         description: Databases to start up. Comma separated list of "name:version"
         required: true
-        default: "[\"mysql:azure\", \"mssql:azure\", \"mssql:mi\", \"postgresql:azure\", \"postgresql:flexible\"]"
+        default: "[\"mysql:azure\", \"mssql:azure\", \"mssql:mi\", \"postgresql:flexible\"]"
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
     outputs:
-      databases: ${{ github.event.inputs.databases || '["mysql:azure","mssql:azure","mssql:mi","postgresql:azure"]' }}
+      databases: ${{ github.event.inputs.databases || '["mysql:azure","mssql:azure","mssql:mi"]' }}
       testClasses: ${{ inputs.testClasses  || 'LiquibaseHarnessSuiteTest' }}
     steps:
       - name: Checkout
@@ -141,28 +141,6 @@ jobs:
           password: "${{secrets.TH_DB_PASSWD}}"
           url: "${{secrets.TH_AZURE_MSSQL_MI_URL}}"
 
-      - name: Azure PostgreSQL Single Server dropAll
-        uses: liquibase-github-actions/drop-all@v4.31.1
-        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'azure' }}
-        with:
-          url: "${{secrets.TH_AZURE_POSTGRESQL_URL}}"
-          username: "${{ format('{0}@{1}', secrets.TH_DB_ADMIN, secrets.TH_AZURE_POSTGRESQL_FQDN) }}"
-          password: "${{secrets.TH_DB_PASSWD}}"
-          licenseKey: "${{secrets.LICENSE_KEY}}"
-          force: true
-          requireForce: true
-
-      - name: Azure PostgreSQL Single Server init changelogs update
-        uses: liquibase/liquibase-github-action@v7
-        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'azure' }}
-        with:
-          operation: "update"
-          classpath: "src/test/resources/init-changelogs/azure"
-          changeLogFile: "postgresql.sql"
-          username: "${{ format('{0}@{1}', secrets.TH_DB_ADMIN, secrets.TH_AZURE_POSTGRESQL_FQDN) }}"
-          password: "${{secrets.TH_DB_PASSWD}}"
-          url: "${{secrets.TH_AZURE_POSTGRESQL_URL}}"
-
       - name: Azure ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Run
         if: ${{ steps.setup.outputs.databasePlatform == 'mysql' }}
         env:
@@ -181,12 +159,6 @@ jobs:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
         run: mvn -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -Dprefix=azure -DdbVersion=mi -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl='${{secrets.TH_AZURE_MSSQL_MI_URL}}' test
 
-      - name: Azure ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Run
-        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'azure' }}
-        env:
-          LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
-        run: mvn -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -Dprefix=azure -DdbVersion=azure -DdbUsername=${{ format('{0}@{1}', secrets.TH_DB_ADMIN, secrets.TH_AZURE_POSTGRESQL_FQDN) }} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl='${{secrets.TH_AZURE_POSTGRESQL_URL}}' test
-        
       - name: Archive Azure ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -159,6 +159,13 @@ jobs:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
         run: mvn -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -Dprefix=azure -DdbVersion=mi -DdbUsername=${{secrets.TH_DB_ADMIN}} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl='${{secrets.TH_AZURE_MSSQL_MI_URL}}' test
 
+      - name: Azure ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Run
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'azure' }}
+        env:
+          LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
+        run: mvn -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -Dprefix=azure -DdbVersion=azure -DdbUsername=${{ format('{0}@{1}', secrets.TH_DB_ADMIN, secrets.TH_AZURE_POSTGRESQL_FQDN) }} -DdbPassword=${{secrets.TH_DB_PASSWD}} -DdbUrl='${{secrets.TH_AZURE_POSTGRESQL_URL}}' test
+        
+        
       - name: Archive Azure ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Results
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 | AWS SQL Server            | `2019`                                | Advanced                       |
 | Azure SQL DB              | `latest`                              | Advanced                       |
 | Azure SQL MI              | `latest`                              | BaseHarnessSuite               |
-| Azure PostgreSQL SS       | `15, 16`                              | Advanced                       |
 | Azure PostgreSQL FlS      | `14, 15, 16`                          | Advanced                       |
 | GCP PostgreSQL            | `12, 13, 14`                          | Advanced                       |
 | GCP MySQL                 | `8`                                   | Advanced                       |


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/azure.yml` workflow file and the `README.md` file to remove support for Azure PostgreSQL Single Server. The most important changes include updating the default databases, removing steps related to Azure PostgreSQL Single Server, and updating the documentation.

Changes to workflow configuration:

* [`.github/workflows/azure.yml`](diffhunk://#diff-633fae241b166c66fdc65768e8f99d046d824d4033b534284a26f5731400bbe6L25-R32): Updated the default databases to remove `postgresql:azure` and adjusted the `outputs` section accordingly.
* [`.github/workflows/azure.yml`](diffhunk://#diff-633fae241b166c66fdc65768e8f99d046d824d4033b534284a26f5731400bbe6L144-L165): Removed steps related to Azure PostgreSQL Single Server, including the `dropAll` and `init changelogs update` steps.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18): Removed Azure PostgreSQL Single Server from the list of supported databases.