### PR TITLE
DAT-19804   DevOps :: test-harness tests :Docker Fails to Start Properly on Ubuntu 24.04 Runners

### DIFF
--- a/src/test/resources/docker/create-infra.sh
+++ b/src/test/resources/docker/create-infra.sh
@@ -19,6 +19,14 @@ case $db in
     exit 0
     ;;
 
+  # MSSQL 2017 needs more time to start properly
+  "mssql-2017")
+    docker compose up -d $db
+    sleep 60
+    docker ps -a
+    docker logs $db
+    ;;
+
   "diff")
     docker compose up -d postgres-17 postgres-16 postgres-14 postgres-13 mysql-5.7 mysql-5.6 mysql-8 mysql-8.4 mariadb-10.4 mariadb-10.5 mariadb-10.6 mariadb-10.7 mssql-2017 mssql-2019 mssql-2022
     sleep 40

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -262,7 +262,6 @@ services:
     volumes:
       - "./mariadb-init.sql:/docker-entrypoint-initdb.d/mariadb-init.sql"
 
-
   mssql-2017:
     container_name: sql-server-db-2017
     image: mcr.microsoft.com/mssql/server:2017-latest
@@ -271,6 +270,8 @@ services:
     environment:
       SA_PASSWORD: "LiquibasePass1"
       ACCEPT_EULA: "Y"
+      MSSQL_PID: "Developer"
+      MSSQL_TCP_PORT: "1433"
     volumes:
       - "./mssql-init.sh:/docker-entrypoint-initdb.d/mssql-init.sh"
       - "./mssql-init.sql:/docker-entrypoint-initdb.d/mssql-init.sql"
@@ -281,6 +282,7 @@ services:
       timeout: 3s
       retries: 10
       start_period: 10s
+    command: /opt/mssql/bin/sqlservr
 
   mssql-2019:
     container_name: sql-server-db-2019


### PR DESCRIPTION
This pull request includes updates to the Docker configuration files to improve the setup and initialization of the MSSQL 2017 service. The most important changes include adding a sleep period to ensure proper startup and modifying the Docker Compose configuration to set environment variables and commands for MSSQL 2017.

Updates to MSSQL 2017 setup:

* [`src/test/resources/docker/create-infra.sh`](diffhunk://#diff-6aff67ea784fdaeea1dd152d94612cf6c551f65779e8e0bf44c456a2f1b5cf35R22-R29): Added a case for `mssql-2017` to include a 60-second sleep period to allow the service to start properly.

Docker Compose configuration changes:

* [`src/test/resources/docker/docker-compose.yml`](diffhunk://#diff-8670a3a54d940f15dff9e03cc33b926ab74700fa6aafc69145737bc64084bb5dR273-R274): Added environment variables `MSSQL_PID` and `MSSQL_TCP_PORT` for the `mssql-2017` service.
* [`src/test/resources/docker/docker-compose.yml`](diffhunk://#diff-8670a3a54d940f15dff9e03cc33b926ab74700fa6aafc69145737bc64084bb5dR285): Added the command `/opt/mssql/bin/sqlservr` to the `mssql-2017` service configuration.
* [`src/test/resources/docker/docker-compose.yml`](diffhunk://#diff-8670a3a54d940f15dff9e03cc33b926ab74700fa6aafc69145737bc64084bb5dL265): Removed an unnecessary blank line in the services section.