### PR TITLE
DAT-20080 DevOps :: Migrate legacy LocalStack API keys to new Auth Tokens

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -76,7 +76,7 @@ jobs:
           pip install localstack awscli-local
           docker pull localstack/localstack-pro
           docker pull mcr.microsoft.com/mssql/server:2019-latest
-          DOCKER_FLAGS='-e MSSQL_ACCEPT_EULA=Y -e MSSQL_IMAGE=mcr.microsoft.com/mssql/server:2019-latest' localstack start -d
+          DOCKER_FLAGS='-e MSSQL_ACCEPT_EULA=Y -e MSSQL_IMAGE=mcr.microsoft.com/mssql/server:2019-latest -e LOCALSTACK_OAUTH_TOKEN=${{ env.LOCALSTACK_OAUTH_TOKEN }}' localstack start -d
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30
           echo "Startup complete"

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -76,7 +76,9 @@ jobs:
           pip install localstack awscli-local
           docker pull localstack/localstack-pro
           docker pull mcr.microsoft.com/mssql/server:2019-latest
-          DOCKER_FLAGS='-e MSSQL_ACCEPT_EULA=Y -e MSSQL_IMAGE=mcr.microsoft.com/mssql/server:2019-latest -e LOCALSTACK_OAUTH_TOKEN=${{ env.LOCALSTACK_OAUTH_TOKEN }}' localstack start -d
+          DOCKER_FLAGS='-e MSSQL_ACCEPT_EULA=Y -e MSSQL_IMAGE=mcr.microsoft.com/mssql/server:2019-latest -e LOCALSTACK_OAUTH_TOKEN=${{ env.LOCALSTACK_OAUTH_TOKEN }}' 
+          localstack auth set-token ${{ env.LOCALSTACK_OAUTH_TOKEN }}
+          localstack start -d
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30
           echo "Startup complete"

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -69,7 +69,7 @@ jobs:
     
       - name: Start & Configure LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_OAUTH_TOKEN: ${{ secrets.LOCALSTACK_OAUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           RDS_MYSQL_DOCKER: 1     #https://docs.localstack.cloud/user-guide/aws/rds/#mysql-engine
         run: |

--- a/README.localstack.md
+++ b/README.localstack.md
@@ -16,7 +16,7 @@ Check out the full `localstack` RDS documentation [here](https://docs.localstack
 Before creating local instances and running your tests, start `localstack` by running the following command:
 
 ```bash
-export LOCALSTACK_API_KEY=<YOUR_LOCAL_STACK_API_KEY>
+export LOCALSTACK_OAUTH_TOKEN=<YOUR_LOCAL_STACK_OAUTH_TOKEN>
 localstack start -d
 ```
 

--- a/README.localstack.md
+++ b/README.localstack.md
@@ -16,7 +16,7 @@ Check out the full `localstack` RDS documentation [here](https://docs.localstack
 Before creating local instances and running your tests, start `localstack` by running the following command:
 
 ```bash
-export LOCALSTACK_OAUTH_TOKEN=<YOUR_LOCAL_STACK_OAUTH_TOKEN>
+localstack auth set-token <THE TOKEN IS IN BITWARDEN>
 localstack start -d
 ```
 


### PR DESCRIPTION
This pull request updates the authentication mechanism for LocalStack by replacing the use of `LOCALSTACK_API_KEY` with `LOCALSTACK_OAUTH_TOKEN` in both the GitHub Actions workflow and the documentation. 

### Updates to LocalStack authentication:

* [`.github/workflows/aws.yml`](diffhunk://#diff-30da5423bd49b3f1dfdb92f40038a27f5747f4b8af0ed81ca3a8e2691be18e69L72-R72): Replaced `LOCALSTACK_API_KEY` with `LOCALSTACK_OAUTH_TOKEN` in the environment variables for the "Start & Configure LocalStack" job.
* [`README.localstack.md`](diffhunk://#diff-1cc81e856cf09df88220f57179c3345afc776a452783897f167ffff43ab7e769L19-R19): Updated the example command to export `LOCALSTACK_OAUTH_TOKEN` instead of `LOCALSTACK_API_KEY` in the LocalStack setup instructions.