### PR TITLE
DAT-20178: use GITHUB_TOKEN and GitHub App token for creating status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,6 +335,7 @@ jobs:
     permissions:
       contents: write
       statuses: write
+      pull-requests: write  
     needs: [ setup, test, authorize ]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,8 +115,11 @@ jobs:
     name: Setup
     needs: authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
     env:
-      GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
+      INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
     outputs:
       liquibaseOwner: ${{ steps.configure-build.outputs.liquibaseOwner }}
       liquibaseBranch: ${{ steps.configure-build.outputs.liquibaseBranch }}
@@ -224,12 +227,12 @@ jobs:
                 {
                   "id": "liquibase-pro",
                   "username": "liquibot",
-                  "password": "${{ secrets.LIQUIBOT_PAT }}"
+                  "password": "${{ secrets.GITHUB_TOKEN }}"
                 },
                 {
                   "id": "liquibase",
                   "username": "liquibot",
-                  "password": "${{ secrets.LIQUIBOT_PAT }}"
+                  "password": "${{ secrets.GITHUB_TOKEN }}"
                 }
               ]
 
@@ -241,7 +244,7 @@ jobs:
 
       - name: Install Snapshot Liquibase
         env:
-          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
+          INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
           mvn -B liquibase-sdk:install-snapshot \
@@ -307,7 +310,7 @@ jobs:
 
       - name: Configure Liquibase Version
         env:
-          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
+          INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
 
@@ -342,7 +345,7 @@ jobs:
       - name: Coordinate Liquibase-Test-Harness
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const helper = require('./.github/util/workflow-helper.js')({github, context});
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,8 +119,7 @@ jobs:
       contents: write
       packages: read
     env:
-      INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
     outputs:
       liquibaseOwner: ${{ steps.configure-build.outputs.liquibaseOwner }}
       liquibaseBranch: ${{ steps.configure-build.outputs.liquibaseBranch }}
@@ -243,7 +242,7 @@ jobs:
 
       - name: Install Snapshot Liquibase
         env:
-          INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
+          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
           mvn -B liquibase-sdk:install-snapshot \
@@ -309,7 +308,7 @@ jobs:
 
       - name: Configure Liquibase Version
         env:
-          INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
+          GITHUB_TOKEN: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -348,7 +348,7 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: liquibase
           repositories: liquibase
-          permissions-statuses: write
+          permission-statuses: write
 
       - name: Coordinate Liquibase-Test-Harness
         uses: actions/github-script@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,12 +226,10 @@ jobs:
               [
                 {
                   "id": "liquibase-pro",
-                  "username": "liquibot",
                   "password": "${{ secrets.GITHUB_TOKEN }}"
                 },
                 {
                   "id": "liquibase",
-                  "username": "liquibot",
                   "password": "${{ secrets.GITHUB_TOKEN }}"
                 }
               ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
       packages: read
     env:
       INSTALL_SNAPSHOT_LIQUIBASE: ${{ secrets.INSTALL_SNAPSHOT_LIQUIBASE }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       liquibaseOwner: ${{ steps.configure-build.outputs.liquibaseOwner }}
       liquibaseBranch: ${{ steps.configure-build.outputs.liquibaseBranch }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,16 +335,25 @@ jobs:
     permissions:
       contents: write
       statuses: write
-      pull-requests: write  
     needs: [ setup, test, authorize ]
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: liquibase
+          repositories: liquibase
+          permission-packages: write
+
       - name: Coordinate Liquibase-Test-Harness
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const helper = require('./.github/util/workflow-helper.js')({github, context});
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -348,7 +348,7 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: liquibase
           repositories: liquibase
-          permission-packages: write
+          permissions-statuses: write
 
       - name: Coordinate Liquibase-Test-Harness
         uses: actions/github-script@v7


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/main.yml` to enhance security and streamline token management. The most important changes involve replacing hardcoded personal access tokens (PATs) with dynamically generated GitHub App tokens and updating permissions for better access control.

### Security and Token Management:

* Updated the `Setup` job to include explicit permissions (`contents: write` and `packages: read`) for better access control.
* Replaced hardcoded `LIQUIBOT_PAT` secrets with the dynamically generated `${{ secrets.GITHUB_TOKEN }}` for authentication in the workflow.
* Added a new step to generate a GitHub App token using the `actions/create-github-app-token@v1` action. This step retrieves the token using the app's ID and private key, ensuring secure and dynamic token generation.

### Workflow Enhancements:

* Modified the `Coordinate Liquibase-Test-Harness` step to use the dynamically generated GitHub App token (`steps.get-token.outputs.token`) instead of a static `BOT_TOKEN` secret, improving security and reducing reliance on static secrets.