### PR TITLE
DAT-20178: use LIQUIBOT_PAT_GPM_ACCESS instead of a BOT_TOKEN

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -251,7 +251,7 @@ jobs:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: liquibase
-          repositories: ${{ needs.setup.outputs.liquibaseRepo }}
+          repositories: liquibase
           permission-statuses: write 
 
       - name: Cache installed Liquibase

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -25,10 +25,11 @@ on:
       databases:
         description: Databases to start up. Comma separated list of "name"
         required: true
-        default: "[\"mysql-5.6\",\"mysql-5.7\",\"mysql-8\",\"mysql-8.4\",\"postgres-12\",\"postgres-13\",\"postgres-14\",\"postgres-15\",\"postgres-16\",\"postgres-17\",\"mariadb-10.2\",\"mariadb-10.3\",\"mariadb-10.4\",\"mariadb-10.5\",\"mariadb-10.6\",
-        \"mariadb-10.7\",\"mariadb-11.4\",\"mssql-2017\",\"mssql-2019\",\"mssql-2022\",\"crdb-23.1\",\"crdb-23.2\",\"crdb-24.1\",\"percona-xtradb-cluster-5.7\",\"percona-xtradb-cluster-8.0\",\"edb-postgres-12\",\"edb-postgres-13\",\"edb-postgres-14\",
-        \"edb-postgres-15\",\"edb-postgres-16\",\"edb-edb-12\",\"edb-edb-13\",\"edb-edb-14\",\"edb-edb-15\",\"edb-edb-16\",\"db2-luw\",\"H2Database-2.2\",\"sqlite\",\"derby\",
-        \"firebird-3\",\"firebird-4\",\"hsqldb-2.5\",\"hsqldb-2.6\",\"hsqldb-2.7\",\"tidb\",\"informix-12.10\",\"informix-14.10\",\"tidb\",\"diff\",\"diffChangelog\"]"
+        default: |
+          ["mysql-5.6","mysql-5.7","mysql-8","mysql-8.4","postgres-12","postgres-13","postgres-14","postgres-15","postgres-16","postgres-17","mariadb-10.2","mariadb-10.3","mariadb-10.4","mariadb-10.5","mariadb-10.6",
+          "mariadb-10.7","mariadb-11.4","mssql-2017","mssql-2019","mssql-2022","crdb-23.1","crdb-23.2","crdb-24.1","percona-xtradb-cluster-5.7","percona-xtradb-cluster-8.0","edb-postgres-12","edb-postgres-13","edb-postgres-14",
+          "edb-postgres-15","edb-postgres-16","edb-edb-12","edb-edb-13","edb-edb-14","edb-edb-15","edb-edb-16","db2-luw","H2Database-2.2","sqlite","derby",
+          "firebird-3","firebird-4","hsqldb-2.5","hsqldb-2.6","hsqldb-2.7","tidb","informix-12.10","informix-14.10","tidb","diff","diffChangelog"]
 
 jobs:
   check_build_safety:
@@ -62,7 +63,7 @@ jobs:
         id: configure-build
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          github-token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
           script: |
             const helper = require('./.github/util/workflow-helper.js')({github, context});
 
@@ -110,49 +111,49 @@ jobs:
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22
         with:
-            repositories: |
-              [
-                {
-                  "id": "liquibase",
-                  "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                  "releases": {
-                    "enabled": "false"
-                  },
-                  "snapshots": {
-                    "enabled": "true",
-                    "updatePolicy": "always"
-                  }
+          repositories: |
+            [
+              {
+                "id": "liquibase",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase",
+                "releases": {
+                  "enabled": "false"
                 },
-                {
-                  "id": "liquibase-pro",
-                  "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                  "releases": {
-                    "enabled": "false"
-                  },
-                  "snapshots": {
-                    "enabled": "true",
-                    "updatePolicy": "always"
-                  }
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
                 }
-              ]
-            servers: |
-              [
-                {
-                  "id": "liquibase-pro",
-                  "username": "liquibot",
-                  "password": "${{ secrets.LIQUIBOT_PAT }}"
+              },
+              {
+                "id": "liquibase-pro",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+                "releases": {
+                  "enabled": "false"
                 },
-                {
-                  "id": "liquibase",
-                  "username": "liquibot",
-                  "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
                 }
-              ]
+              }
+            ]
+          servers: |
+            [
+              {
+                "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+              },
+              {
+                "id": "liquibase",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+              }
+            ]
 
       - name: Install Snapshot Liquibase
         if: steps.configure-build.outputs.useLiquibaseSnapshot == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
           mvn -B liquibase-sdk:install-snapshot \
@@ -213,7 +214,7 @@ jobs:
       - name: Configure Liquibase Version
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
 
@@ -243,6 +244,16 @@ jobs:
       - uses: actions/checkout@v4
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: liquibase
+          repositories: ${{ needs.setup.outputs.liquibaseRepo }}
+          permission-statuses: write 
+
       - name: Cache installed Liquibase
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
         uses: actions/cache@v4
@@ -253,7 +264,7 @@ jobs:
       - name: Update status
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           mvn -B versions:set-property -Dproperty=liquibase-core.version -DnewVersion=0-SNAPSHOT
 

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Start & Configure LocalStack
         env:
           LOCALSTACK_OAUTH_TOKEN: ${{ secrets.LOCALSTACK_OAUTH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
           RDS_MYSQL_DOCKER: 1     #https://docs.localstack.cloud/user-guide/aws/rds/#mysql-engine
         run: |
           pip install localstack awscli-local


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to improve security and streamline token usage. The most significant changes include replacing generic tokens with more specific ones, introducing a GitHub App token, and reformatting the default database list for better readability.

### Security and token management updates:

* Replaced `BOT_TOKEN` with `LIQUIBOT_PAT_GPM_ACCESS` for improved token specificity in multiple steps across `.github/workflows/advanced.yml` and `.github/workflows/aws.yml`. [[1]](diffhunk://#diff-92e6e09976406d5c12da9490bac6dc147bb1c217e688025ed0e3f949b8e71aecL65-R66) [[2]](diffhunk://#diff-92e6e09976406d5c12da9490bac6dc147bb1c217e688025ed0e3f949b8e71aecL143-R156) [[3]](diffhunk://#diff-30da5423bd49b3f1dfdb92f40038a27f5747f4b8af0ed81ca3a8e2691be18e69L73-R73)
* Introduced the use of a GitHub App token by adding a step to generate it (`actions/create-github-app-token@v1`) in `.github/workflows/advanced.yml`. This token is used to update statuses securely. [[1]](diffhunk://#diff-92e6e09976406d5c12da9490bac6dc147bb1c217e688025ed0e3f949b8e71aecR247-R256) [[2]](diffhunk://#diff-92e6e09976406d5c12da9490bac6dc147bb1c217e688025ed0e3f949b8e71aecL256-R267)
* Replaced `BOT_TOKEN` with `GITHUB_TOKEN` in a specific step to align with standard GitHub token usage.

### Workflow readability improvement:

* Reformatted the default database list in `.github/workflows/advanced.yml` to use a multi-line format, enhancing readability without changing functionality.