### PR TITLE
🔧 uses: actions/create-github-app-token@v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -342,7 +342,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `actions/create-github-app-token` action.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L345-R345): Updated the `uses` field for the `Get GitHub App token` step to use version `v2` of the `actions/create-github-app-token` action instead of `v1`.