### PR TITLE
DAT-20416 Fix AWS MSSQL 2019 instance for the interop team

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -96,7 +96,7 @@ jobs:
           docker pull mcr.microsoft.com/mssql/server:2019-latest
           DOCKER_FLAGS='-e MSSQL_ACCEPT_EULA=Y -e MSSQL_IMAGE=mcr.microsoft.com/mssql/server:2019-latest -e LOCALSTACK_OAUTH_TOKEN=${{ env.LOCALSTACK_OAUTH_TOKEN }}' 
           localstack auth set-token ${{ env.LOCALSTACK_OAUTH_TOKEN }}
-          localstack start -d
+          MSSQL_ACCEPT_EULA=Y localstack start -d
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30
           echo "Startup complete"


### PR DESCRIPTION
This pull request updates the `.github/workflows/aws.yml` file to adjust the startup command for LocalStack. The change ensures that the `MSSQL_ACCEPT_EULA` environment variable is explicitly set during the LocalStack startup process.

Workflow configuration updates:

* [`.github/workflows/aws.yml`](diffhunk://#diff-30da5423bd49b3f1dfdb92f40038a27f5747f4b8af0ed81ca3a8e2691be18e69L99-R99): Modified the LocalStack startup command to include `MSSQL_ACCEPT_EULA=Y`, aligning the environment variable setup with the requirements for running the MSSQL server.