### PR TITLE
DAT-20624: use appropriate private key for LIQUIBASETH user

### DIFF
--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -52,18 +52,22 @@ jobs:
           secret-ids: |
             TH_SNOW_URL_GH, liquibaseth_url
             TH_SNOW_USER_GH, liquibaseth_usrname
+      - name: Write secrets to files
+        run: |
+          echo "$TH_SNOW_URL_GH" > snowflake_url
+          echo "$TH_SNOW_USER_GH" > snowflake_user
 
       - name: download the TH_SNOW_URL_GH
         uses: actions/upload-artifact@v4
         with:
           name: TH_SNOW_URL_GH
-          path: /tmp/snowflake_url
+          path: snowflake_url
 
       - name: download TH_SNOW_USER_GH
         uses: actions/upload-artifact@v4
         with:
           name: TH_SNOW_USER_GH
-          path: /tmp/snowflake_user
+          path: snowflake_user
 
   #     - name: Install Liquibase
   #       run: |

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -11,6 +11,7 @@ permissions:
   id-token: write
 
 jobs:
+  # verify validity of this job `deploy-ephemeral-cloud-infra` in https://datical.atlassian.net/browse/DAT-20624?focusedCommentId=170423
   deploy-ephemeral-cloud-infra:
     uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
     secrets: inherit
@@ -51,7 +52,6 @@ jobs:
         with:
           secret-ids: |
             TH_SNOW_URL_GH, liquibaseth_url
-            TH_SNOW_USER_GH, liquibaseth_usrname
 
       - name: Install Liquibase
         run: |
@@ -64,14 +64,14 @@ jobs:
 
       - name: Decode Private Key
         run: |
-          echo "${{ env.TH_DB_PRIVATE_KEY }}" | awk '{gsub("\\\\n","\n")}1' > /tmp/snowflake_private_key.p8
+          echo "${{ env.TH_DB_LIQUIBASETH_PRIVATE_KEY }}" | awk '{gsub("\\\\n","\n")}1' > /tmp/snowflake_private_key.p8
           chmod 600 /tmp/snowflake_private_key.p8  # Secure the key file
 
       - name: Create Liquibase Properties File
         run: |
           cat > liquibase.properties << EOF
           # Snowflake connection settings with database in URL
-          url=${liquibaseth_jdbc_url}
+          url=${TH_SNOW_URL_GH}
           username=LIQUIBASETH
           driver=net.snowflake.client.jdbc.SnowflakeDriver
 
@@ -103,7 +103,7 @@ jobs:
               -DconfigFile=/harness-config-cloud.yml \
               -DdbName=snowflake \
               -DdbUsername=LIQUIBASETH \
-              -DdbUrl='${{env.liquibaseth_jdbc_url}}&private_key_file=/tmp/snowflake_private_key.p8' \
+              -DdbUrl='${{env.TH_SNOW_URL_GH}}&private_key_file=/tmp/snowflake_private_key.p8' \
               -Ddriver=net.snowflake.client.jdbc.SnowflakeDriver \
               -DrollbackStrategy=rollbackByTag test
 
@@ -129,6 +129,7 @@ jobs:
           stack-id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
           run-id: ${{ github.run_id }}
 
+  # verify validity of this job `destroy-ephemeral-cloud-infra` in https://datical.atlassian.net/browse/DAT-20624?focusedCommentId=170423
   destroy-ephemeral-cloud-infra:
     if: always()
     needs: [ deploy-ephemeral-cloud-infra, test, get-stack-id ]

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -11,16 +11,16 @@ permissions:
   id-token: write
 
 jobs:
-  # deploy-ephemeral-cloud-infra:
-  #   uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
-  #   secrets: inherit
-  #   with:
-  #       deploy: true
-  #       snowflake_th: true
+  deploy-ephemeral-cloud-infra:
+    uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
+    secrets: inherit
+    with:
+        deploy: true
+        snowflake_th: true
 
   test:
     runs-on: ubuntu-latest
-    # needs: [deploy-ephemeral-cloud-infra]
+    needs: [deploy-ephemeral-cloud-infra]
 
     steps:
       - name: Checkout
@@ -52,105 +52,89 @@ jobs:
           secret-ids: |
             TH_SNOW_URL_GH, liquibaseth_url
             TH_SNOW_USER_GH, liquibaseth_usrname
-      - name: Write secrets to files
+
+      - name: Install Liquibase
         run: |
-          echo "$TH_SNOW_URL_GH" > snowflake_url
-          echo "$TH_SNOW_USER_GH" > snowflake_user
+          # Add Liquibase repository and install via apt
+          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+          sudo apt-get update
+          sudo apt-get install liquibase
 
-      - name: download the TH_SNOW_URL_GH
+      - name: Decode Private Key
+        run: |
+          echo "${{ env.TH_DB_PRIVATE_KEY }}" | awk '{gsub("\\\\n","\n")}1' > /tmp/snowflake_private_key.p8
+          chmod 600 /tmp/snowflake_private_key.p8  # Secure the key file
+
+      - name: Create Liquibase Properties File
+        run: |
+          cat > liquibase.properties << EOF
+          # Snowflake connection settings with database in URL
+          url=${liquibaseth_jdbc_url}
+          username=LIQUIBASETH
+          driver=net.snowflake.client.jdbc.SnowflakeDriver
+
+          # PKI Authentication
+          liquibase.snowflake.auth.type=PKI
+          liquibase.snowflake.auth.privateKeyPath=/tmp/snowflake_private_key.p8
+          
+          # Schema configuration
+          liquibaseSchemaName=PUBLIC
+          defaultSchemaName=PUBLIC
+          
+          # Changelog settings
+          changeLogFile=snowflake.sql
+          classpath=src/test/resources/init-changelogs/snowflake
+          EOF
+
+      - name: Run Liquibase Update
+        env:
+          LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+        run: |
+          liquibase --defaults-file=liquibase.properties update
+
+      - name: Snowflake Test Run
+        env:
+          LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+        run: |
+          JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" \
+          mvn -Dtest=LiquibaseHarnessSuiteTest \
+              -DconfigFile=/harness-config-cloud.yml \
+              -DdbName=snowflake \
+              -DdbUsername=LIQUIBASETH \
+              -DdbUrl='${{env.liquibaseth_jdbc_url}}&private_key_file=/tmp/snowflake_private_key.p8' \
+              -Ddriver=net.snowflake.client.jdbc.SnowflakeDriver \
+              -DrollbackStrategy=rollbackByTag test
+
+      - name: Archive Snowflake Database Test Results
         uses: actions/upload-artifact@v4
         with:
-          name: TH_SNOW_URL_GH
-          path: snowflake_url
+          name: snowflake-test-results
+          path: build/spock-reports
 
-      - name: download TH_SNOW_USER_GH
-        uses: actions/upload-artifact@v4
+  get-stack-id:
+    if: always()
+    needs: [ deploy-ephemeral-cloud-infra, test ]
+    runs-on: ubuntu-latest
+    outputs:
+      stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Get Stack ID
+        id: get-stack-id
+        uses: ./.github/actions/get-stack-id
         with:
-          name: TH_SNOW_USER_GH
-          path: snowflake_user
+          stack-id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
+          run-id: ${{ github.run_id }}
 
-  #     - name: Install Liquibase
-  #       run: |
-  #         # Add Liquibase repository and install via apt
-  #         wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-  #         cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-  #         echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-  #         sudo apt-get update
-  #         sudo apt-get install liquibase
-
-  #     - name: Decode Private Key
-  #       run: |
-  #         echo "${{ env.TH_DB_PRIVATE_KEY }}" | awk '{gsub("\\\\n","\n")}1' > /tmp/snowflake_private_key.p8
-  #         chmod 600 /tmp/snowflake_private_key.p8  # Secure the key file
-
-  #     - name: Create Liquibase Properties File
-  #       run: |
-  #         cat > liquibase.properties << EOF
-  #         # Snowflake connection settings with database in URL
-  #         url=${TH_SNOW_URL_GH}
-  #         username=${TH_SNOW_USER_GH}
-  #         driver=net.snowflake.client.jdbc.SnowflakeDriver
-
-  #         # PKI Authentication
-  #         liquibase.snowflake.auth.type=PKI
-  #         liquibase.snowflake.auth.privateKeyPath=/tmp/snowflake_private_key.p8
-          
-  #         # Schema configuration
-  #         liquibaseSchemaName=PUBLIC
-  #         defaultSchemaName=PUBLIC
-          
-  #         # Changelog settings
-  #         changeLogFile=snowflake.sql
-  #         classpath=src/test/resources/init-changelogs/snowflake
-  #         EOF
-
-  #     - name: Run Liquibase Update
-  #       env:
-  #         LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-  #       run: |
-  #         liquibase --defaults-file=liquibase.properties update
-
-  #     - name: Snowflake Test Run
-  #       env:
-  #         LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-  #       run: |
-  #         JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" \
-  #         mvn -Dtest=LiquibaseHarnessSuiteTest \
-  #             -DconfigFile=/harness-config-cloud.yml \
-  #             -DdbName=snowflake \
-  #             -DdbUsername=${{env.TH_SNOW_USER_GH}} \
-  #             -DdbUrl='${{env.TH_SNOW_URL_GH}}&private_key_file=/tmp/snowflake_private_key.p8' \
-  #             -Ddriver=net.snowflake.client.jdbc.SnowflakeDriver \
-  #             -DrollbackStrategy=rollbackByTag test
-
-  #     - name: Archive Snowflake Database Test Results
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: snowflake-test-results
-  #         path: build/spock-reports
-
-  # get-stack-id:
-  #   if: always()
-  #   needs: [ deploy-ephemeral-cloud-infra, test ]
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v5
-  #     - name: Get Stack ID
-  #       id: get-stack-id
-  #       uses: ./.github/actions/get-stack-id
-  #       with:
-  #         stack-id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
-  #         run-id: ${{ github.run_id }}
-
-  # destroy-ephemeral-cloud-infra:
-  #   if: always()
-  #   needs: [ deploy-ephemeral-cloud-infra, test, get-stack-id ]
-  #   uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
-  #   secrets: inherit
-  #   with:
-  #       destroy: true
-  #       stack_id: ${{ needs.get-stack-id.outputs.stack-id }}
-  #       snowflake_th: true
+  destroy-ephemeral-cloud-infra:
+    if: always()
+    needs: [ deploy-ephemeral-cloud-infra, test, get-stack-id ]
+    uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
+    secrets: inherit
+    with:
+        destroy: true
+        stack_id: ${{ needs.get-stack-id.outputs.stack-id }}
+        snowflake_th: true

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -54,13 +54,13 @@ jobs:
             TH_SNOW_USER_GH, liquibaseth_usrname
 
       - name: download the TH_SNOW_URL_GH
-        uses: actions/download-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: TH_SNOW_URL_GH
           path: /tmp/snowflake_url
 
       - name: download TH_SNOW_USER_GH
-        uses: actions/download-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: TH_SNOW_USER_GH
           path: /tmp/snowflake_user

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -11,16 +11,16 @@ permissions:
   id-token: write
 
 jobs:
-  deploy-ephemeral-cloud-infra:
-    uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
-    secrets: inherit
-    with:
-        deploy: true
-        snowflake_th: true
+  # deploy-ephemeral-cloud-infra:
+  #   uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
+  #   secrets: inherit
+  #   with:
+  #       deploy: true
+  #       snowflake_th: true
 
   test:
     runs-on: ubuntu-latest
-    needs: [deploy-ephemeral-cloud-infra]
+    # needs: [deploy-ephemeral-cloud-infra]
 
     steps:
       - name: Checkout
@@ -53,88 +53,100 @@ jobs:
             TH_SNOW_URL_GH, liquibaseth_url
             TH_SNOW_USER_GH, liquibaseth_usrname
 
-      - name: Install Liquibase
-        run: |
-          # Add Liquibase repository and install via apt
-          wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
-          cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
-          echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
-          sudo apt-get update
-          sudo apt-get install liquibase
-
-      - name: Decode Private Key
-        run: |
-          echo "${{ env.TH_DB_PRIVATE_KEY }}" | awk '{gsub("\\\\n","\n")}1' > /tmp/snowflake_private_key.p8
-          chmod 600 /tmp/snowflake_private_key.p8  # Secure the key file
-
-      - name: Create Liquibase Properties File
-        run: |
-          cat > liquibase.properties << EOF
-          # Snowflake connection settings with database in URL
-          url=${TH_SNOW_URL_GH}
-          username=${TH_SNOW_USER_GH}
-          driver=net.snowflake.client.jdbc.SnowflakeDriver
-
-          # PKI Authentication
-          liquibase.snowflake.auth.type=PKI
-          liquibase.snowflake.auth.privateKeyPath=/tmp/snowflake_private_key.p8
-          
-          # Schema configuration
-          liquibaseSchemaName=PUBLIC
-          defaultSchemaName=PUBLIC
-          
-          # Changelog settings
-          changeLogFile=snowflake.sql
-          classpath=src/test/resources/init-changelogs/snowflake
-          EOF
-
-      - name: Run Liquibase Update
-        env:
-          LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-        run: |
-          liquibase --defaults-file=liquibase.properties update
-
-      - name: Snowflake Test Run
-        env:
-          LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-        run: |
-          JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" \
-          mvn -Dtest=LiquibaseHarnessSuiteTest \
-              -DconfigFile=/harness-config-cloud.yml \
-              -DdbName=snowflake \
-              -DdbUsername=${{env.TH_SNOW_USER_GH}} \
-              -DdbUrl='${{env.TH_SNOW_URL_GH}}&private_key_file=/tmp/snowflake_private_key.p8' \
-              -Ddriver=net.snowflake.client.jdbc.SnowflakeDriver \
-              -DrollbackStrategy=rollbackByTag test
-
-      - name: Archive Snowflake Database Test Results
-        uses: actions/upload-artifact@v4
+      - name: download the TH_SNOW_URL_GH
+        uses: actions/download-artifact@v5
         with:
-          name: snowflake-test-results
-          path: build/spock-reports
+          name: TH_SNOW_URL_GH
+          path: /tmp/snowflake_url
 
-  get-stack-id:
-    if: always()
-    needs: [ deploy-ephemeral-cloud-infra, test ]
-    runs-on: ubuntu-latest
-    outputs:
-      stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Get Stack ID
-        id: get-stack-id
-        uses: ./.github/actions/get-stack-id
+      - name: download TH_SNOW_USER_GH
+        uses: actions/download-artifact@v5
         with:
-          stack-id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
-          run-id: ${{ github.run_id }}
+          name: TH_SNOW_USER_GH
+          path: /tmp/snowflake_user
 
-  destroy-ephemeral-cloud-infra:
-    if: always()
-    needs: [ deploy-ephemeral-cloud-infra, test, get-stack-id ]
-    uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
-    secrets: inherit
-    with:
-        destroy: true
-        stack_id: ${{ needs.get-stack-id.outputs.stack-id }}
-        snowflake_th: true
+  #     - name: Install Liquibase
+  #       run: |
+  #         # Add Liquibase repository and install via apt
+  #         wget -O- https://repo.liquibase.com/liquibase.asc | gpg --dearmor > liquibase-keyring.gpg && \
+  #         cat liquibase-keyring.gpg | sudo tee /usr/share/keyrings/liquibase-keyring.gpg > /dev/null && \
+  #         echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/liquibase-keyring.gpg] https://repo.liquibase.com stable main' | sudo tee /etc/apt/sources.list.d/liquibase.list
+  #         sudo apt-get update
+  #         sudo apt-get install liquibase
+
+  #     - name: Decode Private Key
+  #       run: |
+  #         echo "${{ env.TH_DB_PRIVATE_KEY }}" | awk '{gsub("\\\\n","\n")}1' > /tmp/snowflake_private_key.p8
+  #         chmod 600 /tmp/snowflake_private_key.p8  # Secure the key file
+
+  #     - name: Create Liquibase Properties File
+  #       run: |
+  #         cat > liquibase.properties << EOF
+  #         # Snowflake connection settings with database in URL
+  #         url=${TH_SNOW_URL_GH}
+  #         username=${TH_SNOW_USER_GH}
+  #         driver=net.snowflake.client.jdbc.SnowflakeDriver
+
+  #         # PKI Authentication
+  #         liquibase.snowflake.auth.type=PKI
+  #         liquibase.snowflake.auth.privateKeyPath=/tmp/snowflake_private_key.p8
+          
+  #         # Schema configuration
+  #         liquibaseSchemaName=PUBLIC
+  #         defaultSchemaName=PUBLIC
+          
+  #         # Changelog settings
+  #         changeLogFile=snowflake.sql
+  #         classpath=src/test/resources/init-changelogs/snowflake
+  #         EOF
+
+  #     - name: Run Liquibase Update
+  #       env:
+  #         LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+  #       run: |
+  #         liquibase --defaults-file=liquibase.properties update
+
+  #     - name: Snowflake Test Run
+  #       env:
+  #         LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+  #       run: |
+  #         JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" \
+  #         mvn -Dtest=LiquibaseHarnessSuiteTest \
+  #             -DconfigFile=/harness-config-cloud.yml \
+  #             -DdbName=snowflake \
+  #             -DdbUsername=${{env.TH_SNOW_USER_GH}} \
+  #             -DdbUrl='${{env.TH_SNOW_URL_GH}}&private_key_file=/tmp/snowflake_private_key.p8' \
+  #             -Ddriver=net.snowflake.client.jdbc.SnowflakeDriver \
+  #             -DrollbackStrategy=rollbackByTag test
+
+  #     - name: Archive Snowflake Database Test Results
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: snowflake-test-results
+  #         path: build/spock-reports
+
+  # get-stack-id:
+  #   if: always()
+  #   needs: [ deploy-ephemeral-cloud-infra, test ]
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v5
+  #     - name: Get Stack ID
+  #       id: get-stack-id
+  #       uses: ./.github/actions/get-stack-id
+  #       with:
+  #         stack-id: ${{ needs.deploy-ephemeral-cloud-infra.outputs.stack_id }}
+  #         run-id: ${{ github.run_id }}
+
+  # destroy-ephemeral-cloud-infra:
+  #   if: always()
+  #   needs: [ deploy-ephemeral-cloud-infra, test, get-stack-id ]
+  #   uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
+  #   secrets: inherit
+  #   with:
+  #       destroy: true
+  #       stack_id: ${{ needs.get-stack-id.outputs.stack-id }}
+  #       snowflake_th: true


### PR DESCRIPTION
Successful run : https://github.com/liquibase/liquibase-test-harness/actions/runs/17869259920 

This pull request updates the `.github/workflows/snowflake.yml` workflow to standardize the use of the `LIQUIBASETH` user and its associated private key for Snowflake authentication, and adds comments to clarify the purpose of certain jobs. The changes help improve security, consistency, and maintainability of the workflow.

**Authentication and User Standardization**
* Updated all references to the Snowflake user and private key to use `LIQUIBASETH` and its corresponding environment variable, ensuring consistent authentication throughout the workflow. [[1]](diffhunk://#diff-a10408a8566b2d8ad461fc462897fba9c698ee7d74531e952bc0d51b2f064908L67-R75) [[2]](diffhunk://#diff-a10408a8566b2d8ad461fc462897fba9c698ee7d74531e952bc0d51b2f064908L105-R105)

**Workflow and Job Documentation**
* Added comments referencing the Jira ticket to clarify the purpose and validity verification of the `deploy-ephemeral-cloud-infra` and `destroy-ephemeral-cloud-infra` jobs. [[1]](diffhunk://#diff-a10408a8566b2d8ad461fc462897fba9c698ee7d74531e952bc0d51b2f064908R14) [[2]](diffhunk://#diff-a10408a8566b2d8ad461fc462897fba9c698ee7d74531e952bc0d51b2f064908R132)

**Secrets Management**
* Removed the unnecessary `TH_SNOW_USER_GH` secret from the list of secret IDs, reflecting the move to the standardized user.