### PR TITLE
Match CockroachDB view definitions with or without trailing semicolon

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/cockroachdb/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/cockroachdb/createPackage.json
@@ -4,7 +4,7 @@
       "liquibase.structure.core.View": [
         {
           "view": {
-            "definition": "SELECT id, first_name, last_name, email FROM lbcat.public.authors",
+            "definition": "SELECT id, first_name, last_name, email FROM lbcat\\.public\\.authors;?",
             "name": "test_view"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/cockroachdb/createView.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/cockroachdb/createView.json
@@ -4,7 +4,7 @@
     "liquibase.structure.core.View": [
       {
         "view": {
-          "definition": "SELECT id, first_name, last_name, email FROM lbcat.public.authors",
+          "definition": "SELECT id, first_name, last_name, email FROM lbcat\\.public\\.authors;?",
           "name": "test_view"
         }
       }]

--- a/src/main/resources/liquibase/harness/snapshot/expectedSnapshot/cockroachdb/createView.json
+++ b/src/main/resources/liquibase/harness/snapshot/expectedSnapshot/cockroachdb/createView.json
@@ -11,7 +11,7 @@
       "liquibase.structure.core.View": [
         {
           "view": {
-            "definition": "SELECT test_column FROM lbcat.public.view_table",
+            "definition": "SELECT test_column FROM lbcat\\.public\\.view_table;?",
             "name": "test_view"
           }
         }


### PR DESCRIPTION
Starting in CockroachDB 26.3, we will be exposing semi-colons at the end of view definitions. Update the expected files to tolerate view definitions with / without semi-colons.