### PR TITLE
[DAT-22660] Test: Replace direct action pins with build-logic composite wrappers

### DIFF
--- a/.github/workflows/OracleRunParallel.yml
+++ b/.github/workflows/OracleRunParallel.yml
@@ -20,7 +20,7 @@ jobs:
         plan: [18.4.0, 19.3.0, 23.2.0]
 
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@main
+      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
       - run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
@@ -28,7 +28,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -41,7 +41,7 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/OracleRunParallel.yml
+++ b/.github/workflows/OracleRunParallel.yml
@@ -20,7 +20,7 @@ jobs:
         plan: [18.4.0, 19.3.0, 23.2.0]
 
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/checkout@main
       - run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
@@ -28,7 +28,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -41,7 +41,7 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/OracleRunParallel.yml
+++ b/.github/workflows/OracleRunParallel.yml
@@ -20,7 +20,7 @@ jobs:
         plan: [18.4.0, 19.3.0, 23.2.0]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: liquibase/build-logic/.github/actions/checkout@main
       - run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
@@ -28,7 +28,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -41,7 +41,7 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -68,10 +68,10 @@ jobs:
       testClasses: ${{ 'AdvancedHarnessSuiteTest' }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -238,7 +238,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -417,16 +417,16 @@ jobs:
         database: ${{ fromJson(needs.setup.outputs.databases) }}
 
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@main
+      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -543,11 +543,11 @@ jobs:
     needs: [ setup, test ]
     if: ${{ always() }}
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@main
+      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -68,10 +68,10 @@ jobs:
       testClasses: ${{ 'AdvancedHarnessSuiteTest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -238,7 +238,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -417,16 +417,16 @@ jobs:
         database: ${{ fromJson(needs.setup.outputs.databases) }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -543,11 +543,11 @@ jobs:
     needs: [ setup, test ]
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: liquibase/build-logic/.github/actions/checkout@main
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -68,10 +68,10 @@ jobs:
       testClasses: ${{ 'AdvancedHarnessSuiteTest' }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -238,7 +238,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -417,16 +417,16 @@ jobs:
         database: ${{ fromJson(needs.setup.outputs.databases) }}
 
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -543,11 +543,11 @@ jobs:
     needs: [ setup, test ]
     if: ${{ always() }}
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/checkout@main
         if: needs.setup.outputs.useLiquibaseSnapshot == 'true'
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -38,7 +38,7 @@ jobs:
       testClasses: ${{ inputs.testClasses  || 'LiquibaseHarnessSuiteTest' }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
   deploy-ephemeral-cloud-infra:
     uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
@@ -69,10 +69,10 @@ jobs:
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (contains(needs.setup.outputs.databases, 'mysql:aws') || contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -86,7 +86,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure Test
         id: setup
@@ -150,7 +150,7 @@ jobs:
             core.setOutput("databaseVersion", splitValues[1]);
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -164,7 +164,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
@@ -291,7 +291,7 @@ jobs:
           password: "${{env.TH_DB_PASSWD}}"
           url: "${{ env.TH_AURORA_POSTGRESQLURL }}"
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -388,7 +388,7 @@ jobs:
       stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
       - name: Get Stack ID
         id: get-stack-id
         uses: ./.github/actions/get-stack-id

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -38,7 +38,7 @@ jobs:
       testClasses: ${{ inputs.testClasses  || 'LiquibaseHarnessSuiteTest' }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
   deploy-ephemeral-cloud-infra:
     uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
@@ -69,10 +69,10 @@ jobs:
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (contains(needs.setup.outputs.databases, 'mysql:aws') || contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -86,7 +86,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure Test
         id: setup
@@ -150,7 +150,7 @@ jobs:
             core.setOutput("databaseVersion", splitValues[1]);
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -164,7 +164,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
@@ -291,7 +291,7 @@ jobs:
           password: "${{env.TH_DB_PASSWD}}"
           url: "${{ env.TH_AURORA_POSTGRESQLURL }}"
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -388,7 +388,7 @@ jobs:
       stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
       - name: Get Stack ID
         id: get-stack-id
         uses: ./.github/actions/get-stack-id

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -38,7 +38,7 @@ jobs:
       testClasses: ${{ inputs.testClasses  || 'LiquibaseHarnessSuiteTest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
   deploy-ephemeral-cloud-infra:
     uses: liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main
@@ -69,10 +69,10 @@ jobs:
     if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (contains(needs.setup.outputs.databases, 'mysql:aws') || contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -86,7 +86,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure Test
         id: setup
@@ -150,7 +150,7 @@ jobs:
             core.setOutput("databaseVersion", splitValues[1]);
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -164,7 +164,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
@@ -291,7 +291,7 @@ jobs:
           password: "${{env.TH_DB_PASSWD}}"
           url: "${{ env.TH_AURORA_POSTGRESQLURL }}"
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -388,7 +388,7 @@ jobs:
       stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
       - name: Get Stack ID
         id: get-stack-id
         uses: ./.github/actions/get-stack-id

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -45,10 +45,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -215,7 +215,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -317,7 +317,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -336,7 +336,7 @@ jobs:
           sudo lpm update && sudo lpm add mysql postgresql mariadb mssql
     
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660 # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -45,10 +45,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -215,7 +215,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -317,7 +317,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -336,7 +336,7 @@ jobs:
           sudo lpm update && sudo lpm add mysql postgresql mariadb mssql
     
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -336,7 +336,7 @@ jobs:
           sudo lpm update && sudo lpm add mysql postgresql mariadb mssql
     
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -45,10 +45,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -215,7 +215,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -317,7 +317,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -336,7 +336,7 @@ jobs:
           sudo lpm update && sudo lpm add mysql postgresql mariadb mssql
     
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main # v6.0.0
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -43,10 +43,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -213,7 +213,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -307,14 +307,14 @@ jobs:
             version: azure
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       #      This additional init step is required because of mysql driver issue on GH actions
       - name: Install Dependencies
         run: lpm update && lpm add mysql
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -359,10 +359,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -439,7 +439,7 @@ jobs:
             --url="${{ env.TH_AZURE_MSSQL_MI_URL }}"
 
       # Setup Java and Maven for test runs (after Liquibase CLI operations)
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -525,10 +525,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -568,7 +568,7 @@ jobs:
             --password="${{ env.TH_DB_PASSWD }}" \
             --url="${{ env[format('TH_AZURE_POSTGRESQL_FLEXIBLE_SERVER_{0}_URL', matrix.version)] }}"
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -43,10 +43,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -213,7 +213,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -307,14 +307,14 @@ jobs:
             version: azure
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       #      This additional init step is required because of mysql driver issue on GH actions
       - name: Install Dependencies
         run: lpm update && lpm add mysql
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -359,10 +359,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -439,7 +439,7 @@ jobs:
             --url="${{ env.TH_AZURE_MSSQL_MI_URL }}"
 
       # Setup Java and Maven for test runs (after Liquibase CLI operations)
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -525,10 +525,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -568,7 +568,7 @@ jobs:
             --password="${{ env.TH_DB_PASSWD }}" \
             --url="${{ env[format('TH_AZURE_POSTGRESQL_FLEXIBLE_SERVER_{0}_URL', matrix.version)] }}"
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -43,10 +43,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -213,7 +213,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -307,14 +307,14 @@ jobs:
             version: azure
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       #      This additional init step is required because of mysql driver issue on GH actions
       - name: Install Dependencies
         run: lpm update && lpm add mysql
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -359,10 +359,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -439,7 +439,7 @@ jobs:
             --url="${{ env.TH_AZURE_MSSQL_MI_URL }}"
 
       # Setup Java and Maven for test runs (after Liquibase CLI operations)
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -525,10 +525,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -568,7 +568,7 @@ jobs:
             --password="${{ env.TH_DB_PASSWD }}" \
             --url="${{ env[format('TH_AZURE_POSTGRESQL_FLEXIBLE_SERVER_{0}_URL', matrix.version)] }}"
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: liquibase/build-logic/.github/actions/checkout@main
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: liquibase/build-logic/.github/actions/checkout@main
+      uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      uses: liquibase/build-logic/.github/actions/checkout@main
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -44,10 +44,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -214,7 +214,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -316,10 +316,10 @@ jobs:
             version: gcp
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -361,10 +361,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -44,10 +44,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -214,7 +214,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -316,10 +316,10 @@ jobs:
             version: gcp
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -361,10 +361,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -44,10 +44,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -214,7 +214,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -316,10 +316,10 @@ jobs:
             version: gcp
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -361,10 +361,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/ibm-cloud-db2z.yml
+++ b/.github/workflows/ibm-cloud-db2z.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/ibm-cloud-db2z.yml
+++ b/.github/workflows/ibm-cloud-db2z.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/ibm-cloud-db2z.yml
+++ b/.github/workflows/ibm-cloud-db2z.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,10 +140,10 @@ jobs:
         "edb-edb-12","edb-edb-13","edb-edb-14","edb-edb-15","edb-edb-16","sqlite","hsqldb-2.5","hsqldb-2.6","hsqldb-2.7","firebird-3","firebird-4","db2-luw","informix-12.10","informix-14.10","tidb"]' }}
       testClasses: ${{ inputs.testClasses || 'LiquibaseHarnessSuiteTest' }}
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -314,7 +314,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -493,10 +493,10 @@ jobs:
         database: ${{ fromJson(needs.setup.outputs.databases) }}
 
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -519,7 +519,7 @@ jobs:
           permission-contents: write
           permission-actions: write
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -676,10 +676,10 @@ jobs:
     needs: [setup, test, authorize]
     if: ${{ always() }}
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,10 +140,10 @@ jobs:
         "edb-edb-12","edb-edb-13","edb-edb-14","edb-edb-15","edb-edb-16","sqlite","hsqldb-2.5","hsqldb-2.6","hsqldb-2.7","firebird-3","firebird-4","db2-luw","informix-12.10","informix-14.10","tidb"]' }}
       testClasses: ${{ inputs.testClasses || 'LiquibaseHarnessSuiteTest' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -314,7 +314,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -493,10 +493,10 @@ jobs:
         database: ${{ fromJson(needs.setup.outputs.databases) }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -519,7 +519,7 @@ jobs:
           permission-contents: write
           permission-actions: write
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -676,10 +676,10 @@ jobs:
     needs: [setup, test, authorize]
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,10 +140,10 @@ jobs:
         "edb-edb-12","edb-edb-13","edb-edb-14","edb-edb-15","edb-edb-16","sqlite","hsqldb-2.5","hsqldb-2.6","hsqldb-2.7","firebird-3","firebird-4","db2-luw","informix-12.10","informix-14.10","tidb"]' }}
       testClasses: ${{ inputs.testClasses || 'LiquibaseHarnessSuiteTest' }}
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@main
+      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -314,7 +314,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -493,10 +493,10 @@ jobs:
         database: ${{ fromJson(needs.setup.outputs.databases) }}
 
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@main
+      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -519,7 +519,7 @@ jobs:
           permission-contents: write
           permission-actions: write
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -676,10 +676,10 @@ jobs:
     needs: [setup, test, authorize]
     if: ${{ always() }}
     steps:
-      - uses: liquibase/build-logic/.github/actions/checkout@main
+      - uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/oracle-oci.yml
+++ b/.github/workflows/oracle-oci.yml
@@ -39,10 +39,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -209,7 +209,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -307,7 +307,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
 
       - name: Restore cached Liquibase artifacts
@@ -320,7 +320,7 @@ jobs:
             mvn-liquibase-${{ github.run_id }}-
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/oracle-oci.yml
+++ b/.github/workflows/oracle-oci.yml
@@ -39,10 +39,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -209,7 +209,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -307,7 +307,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
 
       - name: Restore cached Liquibase artifacts
@@ -320,7 +320,7 @@ jobs:
             mvn-liquibase-${{ github.run_id }}-
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/oracle-oci.yml
+++ b/.github/workflows/oracle-oci.yml
@@ -39,10 +39,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -209,7 +209,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -307,7 +307,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
 
       - name: Restore cached Liquibase artifacts
@@ -320,7 +320,7 @@ jobs:
             mvn-liquibase-${{ github.run_id }}-
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -23,10 +23,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -193,7 +193,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -298,9 +298,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@main
+      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
         with:
           java-version: "17"
           distribution: "temurin"
@@ -316,7 +316,7 @@ jobs:
             mvn-liquibase-${{ github.run_id }}-
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -330,7 +330,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
         with:
             role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
             aws-region: us-east-1
@@ -440,7 +440,7 @@ jobs:
       stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@main
+        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
       - name: Get Stack ID
         id: get-stack-id
         uses: ./.github/actions/get-stack-id

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -23,10 +23,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -193,7 +193,7 @@ jobs:
               }
             ]
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -298,9 +298,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -316,7 +316,7 @@ jobs:
             mvn-liquibase-${{ github.run_id }}-
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -330,7 +330,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
             role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
             aws-region: us-east-1
@@ -440,7 +440,7 @@ jobs:
       stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: liquibase/build-logic/.github/actions/checkout@main
       - name: Get Stack ID
         id: get-stack-id
         uses: ./.github/actions/get-stack-id

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -23,10 +23,10 @@ jobs:
       proVersion: ${{ steps.discover-version.outputs.secure-version }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -193,7 +193,7 @@ jobs:
               }
             ]
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -298,9 +298,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
 
-      - uses: liquibase/build-logic/.github/actions/setup-java@DAT-22660
+      - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
           java-version: "17"
           distribution: "temurin"
@@ -316,7 +316,7 @@ jobs:
             mvn-liquibase-${{ github.run_id }}-
 
       - name: Configure AWS credentials for vault access
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -330,7 +330,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS Credentials
-        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@DAT-22660
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
         with:
             role-to-assume: ${{ env.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
             aws-region: us-east-1
@@ -440,7 +440,7 @@ jobs:
       stack-id: ${{ steps.get-stack-id.outputs.stack-id }}
     steps:
       - name: Checkout
-        uses: liquibase/build-logic/.github/actions/checkout@DAT-22660
+        uses: liquibase/build-logic/.github/actions/checkout@main
       - name: Get Stack ID
         id: get-stack-id
         uses: ./.github/actions/get-stack-id


### PR DESCRIPTION
## Summary

Replace direct SHA-pinned third-party actions with centralized composite action wrappers from `build-logic`.

**Replaced (67 occurrences across 11 workflows):**
- `actions/checkout` -> `liquibase/build-logic/.github/actions/checkout@main`
- `actions/setup-java` -> `liquibase/build-logic/.github/actions/setup-java@main`
- `aws-actions/configure-aws-credentials` -> `liquibase/build-logic/.github/actions/configure-aws-credentials@main`

## Why
- SHAs managed in one place (build-logic) instead of per-repo
- Dependabot updates one repo instead of N repos per action version bump

## Test plan
- [x] Validated all 3 wrappers via test run: https://github.com/liquibase/liquibase-test-harness/actions/runs/24413404967
- [x] All jobs passed (authorize, Setup, test H2Database-2.2, Finish)
- [ ] Merge [build-logic PR #545](https://github.com/liquibase/build-logic/pull/545) first

## Dependencies
- Requires [build-logic#545](https://github.com/liquibase/build-logic/pull/545) to be merged first

Jira: [DAT-22660](https://datical.atlassian.net/browse/DAT-22660)

[DAT-22660]: https://datical.atlassian.net/browse/DAT-22660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ