### PR TITLE
[DAT-22939] Clean up residual master references, rename to main

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -134,7 +134,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -146,7 +146,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -170,7 +170,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -257,8 +257,8 @@ jobs:
           # Determine target branch for artifact discovery
           INPUT_BRANCH="${{ github.event.inputs.liquibaseBranch }}"
           if [ -z "$INPUT_BRANCH" ]; then
-            TARGET_BRANCH="master"
-            echo "No branch specified, defaulting to master for artifact discovery"
+            TARGET_BRANCH="main"
+            echo "No branch specified, defaulting to main for artifact discovery"
           else
             TARGET_BRANCH=$(echo "$INPUT_BRANCH" | cut -d',' -f1 | tr -d ' ')
             echo "Using specified branch for artifact discovery: $TARGET_BRANCH"
@@ -310,12 +310,12 @@ jobs:
             echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
             METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-            # Extract version in {branch}-{7-char-hex-sha} format (e.g., master-e461cb2)
+            # Extract version in {branch}-{7-char-hex-sha} format (e.g., main-e461cb2)
             SECURE_VERSION=$(echo "$METADATA" | grep -o "<version>${TARGET_BRANCH}-[a-f0-9]\{7\}</version>" | tail -1 | sed 's/<[^>]*>//g')
 
-            if [ -z "$SECURE_VERSION" ] && [ "$TARGET_BRANCH" != "master" ]; then
-              echo "No artifact found for branch ${TARGET_BRANCH}, falling back to master"
-              SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+            if [ -z "$SECURE_VERSION" ] && [ "$TARGET_BRANCH" != "main" ]; then
+              echo "No artifact found for branch ${TARGET_BRANCH}, falling back to main"
+              SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
             fi
 
             if [ -z "$SECURE_VERSION" ]; then

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -111,7 +111,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -123,7 +123,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -147,7 +147,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -238,12 +238,12 @@ jobs:
           echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
           METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-          # Extract version in master-{7-char-hex-sha} format (e.g., master-e461cb2)
-          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+          # Extract version in main-{7-char-hex-sha} format (e.g., main-e461cb2)
+          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
 
           if [ -z "$SECURE_VERSION" ]; then
             echo "ERROR: Could not determine PRO version from GitHub Packages"
-            echo "Looking for pattern: master-{7-char-hex-sha} (e.g., master-e461cb2)"
+            echo "Looking for pattern: main-{7-char-hex-sha} (e.g., main-e461cb2)"
             echo "GitHub Packages metadata response (first 500 chars):"
             echo "$METADATA" | head -c 500
             echo ""

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -109,7 +109,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -121,7 +121,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -145,7 +145,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -236,12 +236,12 @@ jobs:
           echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
           METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-          # Extract version in master-{7-char-hex-sha} format (e.g., master-e461cb2)
-          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+          # Extract version in main-{7-char-hex-sha} format (e.g., main-e461cb2)
+          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
 
           if [ -z "$SECURE_VERSION" ]; then
             echo "ERROR: Could not determine PRO version from GitHub Packages"
-            echo "Looking for pattern: master-{7-char-hex-sha} (e.g., master-e461cb2)"
+            echo "Looking for pattern: main-{7-char-hex-sha} (e.g., main-e461cb2)"
             echo "GitHub Packages metadata response (first 500 chars):"
             echo "$METADATA" | head -c 500
             echo ""

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]

--- a/.github/workflows/deploy-main-snapshot.yml
+++ b/.github/workflows/deploy-main-snapshot.yml
@@ -1,4 +1,4 @@
-name: Deploy Master Snapshot
+name: Deploy Main Snapshot
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   id-token: write
 
 jobs:
-  extension-deploy-master-snapshot:
+  extension-deploy-main-snapshot:
     uses: liquibase/build-logic/.github/workflows/build-extension-jar.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -110,7 +110,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -122,7 +122,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -146,7 +146,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -237,12 +237,12 @@ jobs:
           echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
           METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-          # Extract version in master-{7-char-hex-sha} format (e.g., master-e461cb2)
-          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+          # Extract version in main-{7-char-hex-sha} format (e.g., main-e461cb2)
+          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
 
           if [ -z "$SECURE_VERSION" ]; then
             echo "ERROR: Could not determine PRO version from GitHub Packages"
-            echo "Looking for pattern: master-{7-char-hex-sha} (e.g., master-e461cb2)"
+            echo "Looking for pattern: main-{7-char-hex-sha} (e.g., main-e461cb2)"
             echo "GitHub Packages metadata response (first 500 chars):"
             echo "$METADATA" | head -c 500
             echo ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,7 +210,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -222,7 +222,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -246,7 +246,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -333,8 +333,8 @@ jobs:
           # Determine target branch for artifact discovery
           INPUT_BRANCH="${{ github.event.inputs.liquibaseBranch }}"
           if [ -z "$INPUT_BRANCH" ]; then
-            TARGET_BRANCH="master"
-            echo "No branch specified, defaulting to master for artifact discovery"
+            TARGET_BRANCH="main"
+            echo "No branch specified, defaulting to main for artifact discovery"
           else
             TARGET_BRANCH=$(echo "$INPUT_BRANCH" | cut -d',' -f1 | tr -d ' ')
             echo "Using specified branch for artifact discovery: $TARGET_BRANCH"
@@ -386,12 +386,12 @@ jobs:
             echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
             METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-            # Extract version in {branch}-{7-char-hex-sha} format (e.g., master-e461cb2)
+            # Extract version in {branch}-{7-char-hex-sha} format (e.g., main-e461cb2)
             SECURE_VERSION=$(echo "$METADATA" | grep -o "<version>${TARGET_BRANCH}-[a-f0-9]\{7\}</version>" | tail -1 | sed 's/<[^>]*>//g')
 
-            if [ -z "$SECURE_VERSION" ] && [ "$TARGET_BRANCH" != "master" ]; then
-              echo "No artifact found for branch ${TARGET_BRANCH}, falling back to master"
-              SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+            if [ -z "$SECURE_VERSION" ] && [ "$TARGET_BRANCH" != "main" ]; then
+              echo "No artifact found for branch ${TARGET_BRANCH}, falling back to main"
+              SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
             fi
 
             if [ -z "$SECURE_VERSION" ]; then

--- a/.github/workflows/oracle-oci.yml
+++ b/.github/workflows/oracle-oci.yml
@@ -105,7 +105,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -117,7 +117,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -141,7 +141,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -232,12 +232,12 @@ jobs:
           echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
           METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-          # Extract version in master-{7-char-hex-sha} format (e.g., master-e461cb2)
-          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+          # Extract version in main-{7-char-hex-sha} format (e.g., main-e461cb2)
+          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
 
           if [ -z "$SECURE_VERSION" ]; then
             echo "ERROR: Could not determine PRO version from GitHub Packages"
-            echo "Looking for pattern: master-{7-char-hex-sha} (e.g., master-e461cb2)"
+            echo "Looking for pattern: main-{7-char-hex-sha} (e.g., main-e461cb2)"
             echo "GitHub Packages metadata response (first 500 chars):"
             echo "$METADATA" | head -c 500
             echo ""

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -89,7 +89,7 @@ jobs:
 
             core.setOutput("triggeredRepo", triggeredRepo || "liquibase-test-harness");
 
-            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", master";
+            let liquibaseBranchName = "${{ github.event.inputs.liquibaseBranch }}" || testBranchName + ", main";
             console.log("liquibaseBranch == " + liquibaseBranchName);
             core.setOutput("liquibaseBranch", liquibaseBranchName);
 
@@ -101,7 +101,7 @@ jobs:
               console.log("No liquibaseSha passed. Looking for branch "+ liquibaseBranchName);
 
               try {
-                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "master", "main"]);
+                let liquibaseBranchResponse = await helper.findMatchingBranch(repoOwnerName, repoName, [liquibaseBranchName, "main"]);
                 liquibaseSha = liquibaseBranchResponse.sha;
               } catch (error) {
                 // If branch lookup fails and user explicitly selected liquibase-pro, fail hard
@@ -125,7 +125,7 @@ jobs:
                   const fallbackRepo = defaultRepo.split("/")[1];
 
                   try {
-                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "master", "main"]);
+                    let liquibaseBranchResponse = await helper.findMatchingBranch(fallbackOwner, fallbackRepo, [liquibaseBranchName, "main"]);
                     liquibaseSha = liquibaseBranchResponse.sha;
                     liquibaseRepo = defaultRepo;
                     repoOwnerName = fallbackOwner;
@@ -216,12 +216,12 @@ jobs:
           echo "Fetching latest PRO artifact version from: $PACKAGES_URL"
           METADATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PACKAGES_URL")
 
-          # Extract version in master-{7-char-hex-sha} format (e.g., master-e461cb2)
-          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>master-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
+          # Extract version in main-{7-char-hex-sha} format (e.g., main-e461cb2)
+          SECURE_VERSION=$(echo "$METADATA" | grep -o '<version>main-[a-f0-9]\{7\}</version>' | tail -1 | sed 's/<[^>]*>//g')
 
           if [ -z "$SECURE_VERSION" ]; then
             echo "ERROR: Could not determine PRO version from GitHub Packages"
-            echo "Looking for pattern: master-{7-char-hex-sha} (e.g., master-e461cb2)"
+            echo "Looking for pattern: main-{7-char-hex-sha} (e.g., main-e461cb2)"
             echo "GitHub Packages metadata response (first 500 chars):"
             echo "$METADATA" | head -c 500
             echo ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,8 +426,8 @@ Located in `.github/workflows/`:
 - Uses Maven for dependency resolution
 - Queries GitHub Packages maven-metadata.xml for versions
 - Community: `{commit-sha}-SNAPSHOT` format
-- Pro: `master-{short-sha}` format
-- Automatic fallback to master if branch not found
+- Pro: `main-{short-sha}` format
+- Automatic fallback to main if branch not found
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Starting with the Liquibase Secure release, the **main.yml** workflow automatica
 - **Manual workflow dispatch**:
   - Use the `liquibaseRepo` input to manually override the repository (defaults to detected repository)
   - Use the `liquibaseBranch` input to specify which branch to pull artifacts from
-  - If the specified branch doesn't exist, workflows automatically fall back to `master` or `main`
+  - If the specified branch doesn't exist, workflows automatically fall back to `main`
 
 **Advanced & Cloud Workflows (advanced.yml, aws.yml, azure.yml, gcp.yml, oracle-oci.yml, snowflake.yml):**
 - **Always download and use Liquibase Secure (Pro) artifacts**
@@ -139,7 +139,7 @@ All workflows support manual triggering via `workflow_dispatch` with the followi
 - **liquibaseBranch** (optional): Branch to pull artifacts from
   - Can be a single branch name or comma-separated list for fallback search
   - Supports format: `branch1, branch2, branch3`
-  - Default: Current branch name with fallback to `master` then `main`
+  - Default: Current branch name with fallback to `main`
   - Falls back to next branch in list if previous one doesn't exist
 
 - **liquibaseCommit** (optional): Specific commit SHA to pull artifacts from
@@ -149,7 +149,7 @@ All workflows support manual triggering via `workflow_dispatch` with the followi
 - **liquibaseBranch** (optional): Branch to pull artifacts from
   - Can be a single branch name or comma-separated list for fallback search
   - Supports format: `branch1, branch2, branch3`
-  - Default: Current branch name with fallback to `master` then `main`
+  - Default: Current branch name with fallback to `main`
 
 - **liquibaseRepo** (optional): Repository selection input
   - NOTE: This input is ignored for these workflows
@@ -234,12 +234,12 @@ The Maven workflows automatically detect which repository is being used and reso
    - **GitHub Packages Snapshot Versioning**: Artifacts follow specific versioning patterns
    - **Community artifacts** (`liquibase/liquibase`):
      - Version format: `{commit-sha}-SNAPSHOT` (e.g., `e11e704013b5f419e0826807714d72c945dbffd2-SNAPSHOT`)
-     - Workflow queries GitHub Packages maven-metadata.xml to discover latest master branch commit SHA
+     - Workflow queries GitHub Packages maven-metadata.xml to discover latest main branch commit SHA
      - Each commit gets a unique snapshot version automatically published to GitHub Packages
    - **Pro artifacts** (`liquibase/liquibase-pro`):
-     - Version format: `master-{short-sha}` (e.g., `master-e461cb2`, `master-f01cce1`)
-     - Workflow queries GitHub Packages maven-metadata.xml to discover latest master branch version
-     - Each master build gets a unique version with 7-character commit SHA
+     - Version format: `main-{short-sha}` (e.g., `main-e461cb2`, `main-f01cce1`)
+     - Workflow queries GitHub Packages maven-metadata.xml to discover latest main branch version
+     - Each main build gets a unique version with 7-character commit SHA
    - **Automatic Discovery**: Workflow automatically detects which artifacts are needed and queries the appropriate repository's version metadata
 
 3. **Maven Profile**: The `useproartifacts` profile (when activated with `-Puseproartifacts`):
@@ -249,13 +249,13 @@ The Maven workflows automatically detect which repository is being used and reso
 
 4. **Artifact Resolution Flow**:
    - **Pro artifacts** (`liquibase-pro` selected):
-     - Workflow queries and sets version to `master-{short-sha}` (e.g., `master-e461cb2`)
+     - Workflow queries and sets version to `main-{short-sha}` (e.g., `main-e461cb2`)
      - Profile activates `-Puseproartifacts`
      - Maven resolves:
-       - `org.liquibase:liquibase-core:master-{short-sha}` from `liquibase-pro` repository
-       - `com.liquibase:liquibase-commercial:master-{short-sha}` from `liquibase-pro` repository
+       - `org.liquibase:liquibase-core:main-{short-sha}` from `liquibase-pro` repository
+       - `com.liquibase:liquibase-commercial:main-{short-sha}` from `liquibase-pro` repository
    - **Community artifacts** (default):
-     - Workflow queries GitHub Packages maven-metadata.xml for latest master branch commit SHA
+     - Workflow queries GitHub Packages maven-metadata.xml for latest main branch commit SHA
      - Sets version to `{SHA}-SNAPSHOT` (e.g., `e11e704013b5f419e0826807714d72c945dbffd2-SNAPSHOT`)
      - Maven resolves only:
        - `org.liquibase:liquibase-core:{SHA}-SNAPSHOT` from `liquibase` repository


### PR DESCRIPTION
## Summary

Default branch for `liquibase/liquibase-test-harness` is already `main`. This PR cleans up residual `master` references left behind in workflows and docs (per [DAT-22939](https://datical.atlassian.net/browse/DAT-22939), sub-task of [DAT-22090](https://datical.atlassian.net/browse/DAT-22090)).

## What changed

**Workflow rename**
- `.github/workflows/deploy-master-snapshot.yml` → `deploy-main-snapshot.yml`
- Workflow `name:` and job id updated accordingly

**Workflow content updates (9 files)**
- `codeql.yml`: drop `master` from push branch trigger
- `main.yml`, `advanced.yml`, `aws.yml`, `azure.yml`, `gcp.yml`, `oracle-oci.yml`, `snowflake.yml`:
  - `testBranchName + ", master"` → `", main"` fallback for `liquibaseBranchName`
  - `[liquibaseBranchName, "master", "main"]` → `[liquibaseBranchName, "main"]` in `helper.findMatchingBranch(...)` calls
  - `TARGET_BRANCH="master"` → `TARGET_BRANCH="main"` (main/advanced)
  - Artifact-discovery regex `<version>master-[a-f0-9]{7}</version>` → `<version>main-[a-f0-9]{7}</version>`
  - Related `echo` / comment strings updated for consistency

**Docs**
- `README.md`: fallback wording (`master → main` / `master then main`) and artifact version format (`master-{short-sha}` → `main-{short-sha}`)
- `CLAUDE.md`: same artifact-format update

## Intentionally NOT changed

- `--master-username` / `--master-user-password` in `aws.yml` — AWS RDS `create-db-*` CLI flags (DB admin credentials, unrelated to git branches)
- `--master-username` / `--master-user-password` in `README.localstack.md` — same AWS RDS context
- `-d master` in `src/test/resources/docker/mssql-init.sh` — SQL Server system `master` database

## ⚠️ Merge order dependency

The artifact-discovery regex change (`master-{sha}` → `main-{sha}`) depends on:
1. [DAT-22091](https://datical.atlassian.net/browse/DAT-22091) / [liquibase PR #7660](https://github.com/liquibase/liquibase/pull/7660) being merged
2. A `main-SNAPSHOT` (and `main-{sha}`) artifact being published to GitHub Packages by the updated `liquibase/liquibase` build-main workflow
3. Same for `liquibase/liquibase-pro` once its branch migration lands

**Do not merge this PR until the upstream `main-SNAPSHOT` artifacts are confirmed to be publishing**, otherwise the scheduled/dispatch workflows using `main-{sha}` version discovery will find no artifacts and fail.

## Test plan

- [x] Verify DAT-22091 has merged and `main-SNAPSHOT` artifacts are published for `liquibase/liquibase`
- [x] Verify `main-{sha}` versioned artifacts publish for `liquibase/liquibase-pro`
- [x] Manual `workflow_dispatch` of `main.yml` and confirm artifact discovery succeeds on `main`
- [ ] Manual dispatch of `aws.yml` / `azure.yml` / `gcp.yml` to validate cloud-DB test discovery works against the new version pattern
- [ ] Confirm `deploy-main-snapshot.yml` triggers on push-to-main and publishes to GitHub Packages
- [ ] CodeQL scan triggers correctly on push-to-main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22939]: https://datical.atlassian.net/browse/DAT-22939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DAT-22090]: https://datical.atlassian.net/browse/DAT-22090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DAT-22091]: https://datical.atlassian.net/browse/DAT-22091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ