### PR TITLE
refactor(ci): replace archived whelk-io with build-logic setup-maven-settings [DAT-22915]

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -212,30 +212,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main
@@ -439,46 +425,18 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "github-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}},
+              {"id": "github-pro", "url": "https://maven.pkg.github.com/liquibase/liquibase-pro", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "github-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"},
+              {"id": "github-pro", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - name: Restore cached Liquibase artifacts

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -189,30 +189,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -187,30 +187,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main
@@ -445,25 +431,16 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": { "enabled": "true" },
-                "snapshots": { "enabled": "true", "updatePolicy": "always" }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - name: Restore cached Liquibase artifacts

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -188,30 +188,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,30 +288,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main
@@ -525,62 +511,20 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "github-community",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "github-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}},
+              {"id": "github-community", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}},
+              {"id": "github-pro", "url": "https://maven.pkg.github.com/liquibase/liquibase-pro", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "github-community",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "github-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"},
+              {"id": "github-community", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"},
+              {"id": "github-pro", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - name: Restore cached Liquibase artifacts

--- a/.github/workflows/oracle-oci.yml
+++ b/.github/workflows/oracle-oci.yml
@@ -183,30 +183,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -167,30 +167,16 @@ jobs:
                 }
             }
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
           repositories: |
             [
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
+              {"id": "github", "url": "https://maven.pkg.github.com/liquibase/liquibase", "releases": {"enabled": "true"}, "snapshots": {"enabled": "true", "updatePolicy": "always"}}
             ]
           servers: |
             [
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
+              {"id": "github", "username": "liquibot", "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"}
             ]
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main


### PR DESCRIPTION
## Summary

Replace all 10 `whelk-io/maven-settings-xml-action` call sites across 7 workflow files (`advanced.yml`, `aws.yml`, `azure.yml`, `gcp.yml`, `main.yml`, `oracle-oci.yml`, `snowflake.yml`) with the new first-party composite action [`liquibase/build-logic/.github/actions/setup-maven-settings`](https://github.com/liquibase/build-logic/pull/557) — in **advanced mode** (JSON passed through verbatim).

Jira: [DAT-22915](https://datical.atlassian.net/browse/DAT-22915)

## Why advanced mode

None of the call sites fit simple mode — they all use custom repo ids (`github`, `github-community`, `github-pro`) rather than the simple-mode preset's `liquibase` + `liquibase-pro` pair. The URLs point at the Liquibase GPM but via different logical identifiers.

## What changed — 10 sites, 3 patterns

| Pattern | Files | Repositories |
|---|---|---|
| **A** — single `github` repo (community GPM) | `advanced.yml:216`, `aws.yml:193`, `azure.yml:191`, `azure.yml:449`, `gcp.yml:192`, `main.yml:292`, `oracle-oci.yml:187`, `snowflake.yml:171` | 1 repo: `github` → `liquibase/liquibase` |
| **B** — `github` + `github-pro` | `advanced.yml:443` | 2 repos: `github` + `github-pro` → `liquibase/liquibase-pro` |
| **C** — `github` + `github-community` + `github-pro` | `main.yml:529` | 3 repos |

All servers use `liquibot` + `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}`. All snapshots use `updatePolicy=always`.

## Blocked by

🚧 [**liquibase/build-logic#557**](https://github.com/liquibase/build-logic/pull/557) must merge first.

## Test plan

- [x] All 7 modified workflows parse as valid YAML
- [x] No remaining `whelk-io` references (grep)
- [x] Repo ids preserved exactly (`github`, `github-community`, `github-pro`)
- [x] All credentials unchanged (`liquibot` + `LIQUIBOT_PAT_GPM_ACCESS`)
- [x] `updatePolicy: always` preserved on every site
- [ ] CI green post-merge of liquibase/build-logic#557

## Net diff

**-177 lines** — replacing verbose JSON blocks with compact advanced-mode calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22915]: https://datical.atlassian.net/browse/DAT-22915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ