### PR TITLE
[DAT-22909] Update diff expected fixtures for liquibase-commercial master-0bd5478

### DIFF
--- a/src/main/resources/liquibase/harness/diff/expectedDiff/mariadb10.5_to_mariadb10.4-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/mariadb10.5_to_mariadb10.4-pro.txt
@@ -39,6 +39,9 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
 Unexpected Foreign Key(s):
      test_fk(test_table_base[id] -> test_table_reference[test_column])
@@ -51,11 +54,7 @@ Unexpected Function(s):
 Changed Function(s): NONE
 Missing Index(s): NONE
 Unexpected Index(s):
-     PRIMARY UNIQUE  ON lbcat.test_table_base(id)
-     PRIMARY UNIQUE  ON lbcat.test_table_reference(id)
      idx_first_name ON lbcat.test_table_for_index(id)
-     test_column UNIQUE  ON lbcat.test_table_reference(test_column)
-     test_unique_constraint UNIQUE  ON lbcat.test_table_for_uc(id)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
 Unexpected Primary Key(s):

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/mariadb10.7_to_mariadb10.6-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/mariadb10.7_to_mariadb10.6-pro.txt
@@ -39,6 +39,9 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
 Unexpected Foreign Key(s):
      test_fk(test_table_base[id] -> test_table_reference[test_column])
@@ -51,11 +54,7 @@ Unexpected Function(s):
 Changed Function(s): NONE
 Missing Index(s): NONE
 Unexpected Index(s):
-     PRIMARY UNIQUE  ON lbcat.test_table_base(id)
-     PRIMARY UNIQUE  ON lbcat.test_table_reference(id)
      idx_first_name ON lbcat.test_table_for_index(id)
-     test_column UNIQUE  ON lbcat.test_table_reference(test_column)
-     test_unique_constraint UNIQUE  ON lbcat.test_table_for_uc(id)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
 Unexpected Primary Key(s):

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/mssql2022_to_mssql2017-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/mssql2022_to_mssql2017-pro.txt
@@ -1,10 +1,10 @@
-Reference Database: lbuser@jdbc:sqlserver://localhost:1435;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;msiTokenCacheTtl=3600;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=MicrosoftJDBCDriverforSQLServer;applicationIntent=readwrite;(DefaultSchema:dbo)
-Comparison Database: lbuser@jdbc:sqlserver://localhost:1433;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;msiTokenCacheTtl=3600;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=MicrosoftJDBCDriverforSQLServer;applicationIntent=readwrite;(DefaultSchema:dbo)
+Reference Database: lbuser @ jdbc:sqlserver://localhost:1435;concatNullYieldsNull=ON;quotedIdentifier=ON;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;vectorTypeSupport=v1;cacheBulkCopyMetadata=false;bulkCopyForBatchInsertAllowEncryptedValueModifications=false;bulkCopyForBatchInsertTableLock=false;bulkCopyForBatchInsertKeepNulls=false;bulkCopyForBatchInsertKeepIdentity=false;bulkCopyForBatchInsertFireTriggers=false;bulkCopyForBatchInsertCheckConstraints=false;bulkCopyForBatchInsertBatchSize=0;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;calcBigDecimalPrecision=false;useDefaultJaasConfig=false;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;datetimeParameterType=datetime2;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;useDefaultGSSCredential=false;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite; (Default Schema: dbo)
+Comparison Database: lbuser @ jdbc:sqlserver://localhost:1433;concatNullYieldsNull=ON;quotedIdentifier=ON;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;vectorTypeSupport=v1;cacheBulkCopyMetadata=false;bulkCopyForBatchInsertAllowEncryptedValueModifications=false;bulkCopyForBatchInsertTableLock=false;bulkCopyForBatchInsertKeepNulls=false;bulkCopyForBatchInsertKeepIdentity=false;bulkCopyForBatchInsertFireTriggers=false;bulkCopyForBatchInsertCheckConstraints=false;bulkCopyForBatchInsertBatchSize=0;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;calcBigDecimalPrecision=false;useDefaultJaasConfig=false;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;datetimeParameterType=datetime2;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;useDefaultGSSCredential=false;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite; (Default Schema: dbo)
 Compared Schemas: dbo
 Product Name: EQUAL
 Product Version:
-     Reference:   '16.00.4035'
-     Target: '14.00.3460'
+     Reference:   '16.00.4125'
+     Target: '14.00.3525'
 Missing Catalog(s): NONE
 Unexpected Catalog(s): NONE
 Changed Catalog(s): NONE
@@ -12,7 +12,7 @@ Missing Check Constraint(s): NONE
 Unexpected Check Constraint(s): NONE
 Changed Check Constraint(s): NONE
 Missing Column(s): NONE
-Unexpected Column(s):
+Unexpected Column(s): 
      dbo.test_table_for_column.dateColumn
      dbo.test_table_base.id
      dbo.test_table_for_column.id
@@ -36,24 +36,26 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
-Unexpected Foreign Key(s):
+Unexpected Foreign Key(s): 
      test_fk(test_table_base[id] -> test_table_reference[test_column])
 Changed Foreign Key(s): NONE
 Missing Function(s): NONE
-Unexpected Function(s):
+Unexpected Function(s): 
      test_function
      test_function1
      test_function2
 Changed Function(s): NONE
 Missing Index(s): NONE
-Unexpected Index(s):
-     PK_TEST_TABLE_REFERENCE UNIQUE  ON dbo.test_table_reference(test_column)
+Unexpected Index(s): 
      idx_first_name ON dbo.test_table_for_index(id)
-     test_unique_constraint UNIQUE  ON dbo.test_table_base(id)
+     test_table_reference_index ON dbo.test_table_reference(test_column)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
-Unexpected Primary Key(s):
+Unexpected Primary Key(s): 
      PK_TEST_TABLE_BASE on dbo.test_table_base(id)
      PK_TEST_TABLE_REFERENCE on dbo.test_table_reference(test_column)
 Changed Primary Key(s): NONE
@@ -61,32 +63,32 @@ Missing Schema(s): NONE
 Unexpected Schema(s): NONE
 Changed Schema(s): NONE
 Missing Sequence(s): NONE
-Unexpected Sequence(s):
+Unexpected Sequence(s): 
      test_sequence
 Changed Sequence(s): NONE
 Missing Stored Procedure(s): NONE
-Unexpected Stored Procedure(s):
+Unexpected Stored Procedure(s): 
      test_procedure
 Changed Stored Procedure(s): NONE
 Missing Synonym(s): NONE
 Unexpected Synonym(s): NONE
 Changed Synonym(s): NONE
 Missing Table(s): NONE
-Unexpected Table(s):
+Unexpected Table(s): 
      test_table_base
      test_table_for_column
      test_table_for_index
      test_table_reference
 Changed Table(s): NONE
 Missing Trigger(s): NONE
-Unexpected Trigger(s):
+Unexpected Trigger(s): 
      posts::test_trigger
 Changed Trigger(s): NONE
 Missing Unique Constraint(s): NONE
-Unexpected Unique Constraint(s):
+Unexpected Unique Constraint(s): 
      test_unique_constraint on test_table_base(id)
 Changed Unique Constraint(s): NONE
 Missing View(s): NONE
-Unexpected View(s):
+Unexpected View(s): 
      test_view
 Changed View(s): NONE

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/mssql2022_to_mssql2019-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/mssql2022_to_mssql2019-pro.txt
@@ -1,10 +1,10 @@
-Reference Database: lbuser @ jdbc:sqlserver://localhost:1434;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;cacheBulkCopyMetadata=false;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;calcBigDecimalPrecision=false;useDefaultJaasConfig=false;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;datetimeParameterType=datetime2;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;useDefaultGSSCredential=false;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite; (Default Schema: dbo)
-Comparison Database: lbuser @ jdbc:sqlserver://localhost:1435;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;cacheBulkCopyMetadata=false;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;calcBigDecimalPrecision=false;useDefaultJaasConfig=false;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;datetimeParameterType=datetime2;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;useDefaultGSSCredential=false;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite; (Default Schema: dbo)
+Reference Database: lbuser @ jdbc:sqlserver://localhost:1435;concatNullYieldsNull=ON;quotedIdentifier=ON;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;vectorTypeSupport=v1;cacheBulkCopyMetadata=false;bulkCopyForBatchInsertAllowEncryptedValueModifications=false;bulkCopyForBatchInsertTableLock=false;bulkCopyForBatchInsertKeepNulls=false;bulkCopyForBatchInsertKeepIdentity=false;bulkCopyForBatchInsertFireTriggers=false;bulkCopyForBatchInsertCheckConstraints=false;bulkCopyForBatchInsertBatchSize=0;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;calcBigDecimalPrecision=false;useDefaultJaasConfig=false;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;datetimeParameterType=datetime2;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;useDefaultGSSCredential=false;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite; (Default Schema: dbo)
+Comparison Database: lbuser @ jdbc:sqlserver://localhost:1434;concatNullYieldsNull=ON;quotedIdentifier=ON;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;vectorTypeSupport=v1;cacheBulkCopyMetadata=false;bulkCopyForBatchInsertAllowEncryptedValueModifications=false;bulkCopyForBatchInsertTableLock=false;bulkCopyForBatchInsertKeepNulls=false;bulkCopyForBatchInsertKeepIdentity=false;bulkCopyForBatchInsertFireTriggers=false;bulkCopyForBatchInsertCheckConstraints=false;bulkCopyForBatchInsertBatchSize=0;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;calcBigDecimalPrecision=false;useDefaultJaasConfig=false;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;datetimeParameterType=datetime2;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=true;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;useDefaultGSSCredential=false;prepareMethod=prepexec;encrypt=True;disableStatementPooling=true;databaseName=lbcat;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite; (Default Schema: dbo)
 Compared Schemas: dbo
 Product Name: EQUAL
 Product Version:
-     Reference:   '15.00.4375'
-     Target: '16.00.4125'
+     Reference:   '16.00.4125'
+     Target: '15.00.4375'
 Missing Catalog(s): NONE
 Unexpected Catalog(s): NONE
 Changed Catalog(s): NONE
@@ -12,7 +12,7 @@ Missing Check Constraint(s): NONE
 Unexpected Check Constraint(s): NONE
 Changed Check Constraint(s): NONE
 Missing Column(s): NONE
-Unexpected Column(s):
+Unexpected Column(s): 
      dbo.test_table_for_column.dateColumn
      dbo.test_table_base.id
      dbo.test_table_for_column.id
@@ -36,24 +36,26 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
-Unexpected Foreign Key(s):
+Unexpected Foreign Key(s): 
      test_fk(test_table_base[id] -> test_table_reference[test_column])
 Changed Foreign Key(s): NONE
 Missing Function(s): NONE
-Unexpected Function(s):
+Unexpected Function(s): 
      test_function
      test_function1
      test_function2
 Changed Function(s): NONE
 Missing Index(s): NONE
-Unexpected Index(s):
-     PK_TEST_TABLE_REFERENCE UNIQUE  ON dbo.test_table_reference(test_column)
+Unexpected Index(s): 
      idx_first_name ON dbo.test_table_for_index(id)
-     test_unique_constraint UNIQUE  ON dbo.test_table_base(id)
+     test_table_reference_index ON dbo.test_table_reference(test_column)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
-Unexpected Primary Key(s):
+Unexpected Primary Key(s): 
      PK_TEST_TABLE_BASE on dbo.test_table_base(id)
      PK_TEST_TABLE_REFERENCE on dbo.test_table_reference(test_column)
 Changed Primary Key(s): NONE
@@ -61,32 +63,32 @@ Missing Schema(s): NONE
 Unexpected Schema(s): NONE
 Changed Schema(s): NONE
 Missing Sequence(s): NONE
-Unexpected Sequence(s):
+Unexpected Sequence(s): 
      test_sequence
 Changed Sequence(s): NONE
 Missing Stored Procedure(s): NONE
-Unexpected Stored Procedure(s):
+Unexpected Stored Procedure(s): 
      test_procedure
 Changed Stored Procedure(s): NONE
 Missing Synonym(s): NONE
 Unexpected Synonym(s): NONE
 Changed Synonym(s): NONE
 Missing Table(s): NONE
-Unexpected Table(s):
+Unexpected Table(s): 
      test_table_base
      test_table_for_column
      test_table_for_index
      test_table_reference
 Changed Table(s): NONE
 Missing Trigger(s): NONE
-Unexpected Trigger(s):
+Unexpected Trigger(s): 
      posts::test_trigger
 Changed Trigger(s): NONE
 Missing Unique Constraint(s): NONE
-Unexpected Unique Constraint(s):
+Unexpected Unique Constraint(s): 
      test_unique_constraint on test_table_base(id)
 Changed Unique Constraint(s): NONE
 Missing View(s): NONE
-Unexpected View(s):
+Unexpected View(s): 
      test_view
 Changed View(s): NONE

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/mysql8.4_to_mysql5.7-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/mysql8.4_to_mysql5.7-pro.txt
@@ -39,6 +39,9 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
 Unexpected Foreign Key(s):
      test_fk(test_table_base[id] -> test_table_reference[test_column])
@@ -51,11 +54,7 @@ Unexpected Function(s):
 Changed Function(s): NONE
 Missing Index(s): NONE
 Unexpected Index(s):
-     PRIMARY UNIQUE  ON lbcat.test_table_base(id)
-     PRIMARY UNIQUE  ON lbcat.test_table_reference(id)
      idx_first_name ON lbcat.test_table_for_index(id)
-     test_column UNIQUE  ON lbcat.test_table_reference(test_column)
-     test_unique_constraint UNIQUE  ON lbcat.test_table_for_uc(id)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
 Unexpected Primary Key(s):

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/mysql8_to_mysql5.6-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/mysql8_to_mysql5.6-pro.txt
@@ -39,6 +39,9 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
 Unexpected Foreign Key(s):
      test_fk(test_table_base[id] -> test_table_reference[test_column])
@@ -51,11 +54,7 @@ Unexpected Function(s):
 Changed Function(s): NONE
 Missing Index(s): NONE
 Unexpected Index(s):
-     PRIMARY UNIQUE  ON lbcat.test_table_base(id)
-     PRIMARY UNIQUE  ON lbcat.test_table_reference(id)
      idx_first_name ON lbcat.test_table_for_index(id)
-     test_column UNIQUE  ON lbcat.test_table_reference(test_column)
-     test_unique_constraint UNIQUE  ON lbcat.test_table_for_uc(id)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
 Unexpected Primary Key(s):

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/postgresql14_to_postgresql13-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/postgresql14_to_postgresql13-pro.txt
@@ -3,8 +3,8 @@ Comparison Database: lbuser @ jdbc:postgresql://localhost:5437/lbcat (Default Sc
 Compared Schemas: public
 Product Name: EQUAL
 Product Version:
-     Reference:   '14.15 (Debian 14.15-1.pgdg120+1)'
-     Target: '13.18 (Debian 13.18-1.pgdg120+1)'
+     Reference:   '14.22 (Debian 14.22-1.pgdg13+1)'
+     Target: '13.23 (Debian 13.23-1.pgdg13+1)'
 Missing Catalog(s): NONE
 Unexpected Catalog(s): NONE
 Changed Catalog(s): NONE
@@ -12,7 +12,7 @@ Missing Check Constraint(s): NONE
 Unexpected Check Constraint(s): NONE
 Changed Check Constraint(s): NONE
 Missing Column(s): NONE
-Unexpected Column(s):
+Unexpected Column(s): 
      public.test_table_for_column.dateColumn
      public.test_view.email
      public.test_view.first_name
@@ -39,26 +39,25 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
-Unexpected Foreign Key(s):
+Unexpected Foreign Key(s): 
      test_fk(test_table_base[id] -> test_table_reference[test_column])
 Changed Foreign Key(s): NONE
 Missing Function(s): NONE
-Unexpected Function(s):
+Unexpected Function(s): 
      test_function()
      test_function1()
      test_function2()
 Changed Function(s): NONE
 Missing Index(s): NONE
-Unexpected Index(s):
+Unexpected Index(s): 
      idx_first_name ON public.test_table_for_index(id)
-     test_table_base_pkey UNIQUE  ON public.test_table_base(id)
-     test_table_reference_pkey UNIQUE  ON public.test_table_reference(id)
-     test_table_reference_test_column_key UNIQUE  ON public.test_table_reference(test_column)
-     test_unique_constraint UNIQUE  ON public.test_table_for_uc(id)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
-Unexpected Primary Key(s):
+Unexpected Primary Key(s): 
      test_table_base_pkey on public.test_table_base(id)
      test_table_reference_pkey on public.test_table_reference(id)
 Changed Primary Key(s): NONE
@@ -66,18 +65,18 @@ Missing Schema(s): NONE
 Unexpected Schema(s): NONE
 Changed Schema(s): NONE
 Missing Sequence(s): NONE
-Unexpected Sequence(s):
+Unexpected Sequence(s): 
      test_sequence
 Changed Sequence(s): NONE
 Missing Stored Procedure(s): NONE
-Unexpected Stored Procedure(s):
+Unexpected Stored Procedure(s): 
      test_procedure
 Changed Stored Procedure(s): NONE
 Missing Synonym(s): NONE
 Unexpected Synonym(s): NONE
 Changed Synonym(s): NONE
 Missing Table(s): NONE
-Unexpected Table(s):
+Unexpected Table(s): 
      test_table_base
      test_table_for_column
      test_table_for_index
@@ -85,15 +84,15 @@ Unexpected Table(s):
      test_table_reference
 Changed Table(s): NONE
 Missing Trigger(s): NONE
-Unexpected Trigger(s):
+Unexpected Trigger(s): 
      posts::test_trigger
 Changed Trigger(s): NONE
 Missing Unique Constraint(s): NONE
-Unexpected Unique Constraint(s):
+Unexpected Unique Constraint(s): 
      test_table_reference_test_column_key on test_table_reference(test_column)
      test_unique_constraint on test_table_for_uc(id)
 Changed Unique Constraint(s): NONE
 Missing View(s): NONE
-Unexpected View(s):
+Unexpected View(s): 
      test_view
 Changed View(s): NONE

--- a/src/main/resources/liquibase/harness/diff/expectedDiff/postgresql17_to_postgresql16-pro.txt
+++ b/src/main/resources/liquibase/harness/diff/expectedDiff/postgresql17_to_postgresql16-pro.txt
@@ -1,10 +1,10 @@
-Reference Database: lbuser @ jdbc:postgresql://localhost:5438/lbcat (Default Schema: public)
-Comparison Database: lbuser @ jdbc:postgresql://localhost:5437/lbcat (Default Schema: public)
+Reference Database: lbuser @ jdbc:postgresql://localhost:5441/lbcat (Default Schema: public)
+Comparison Database: lbuser @ jdbc:postgresql://localhost:5440/lbcat (Default Schema: public)
 Compared Schemas: public
 Product Name: EQUAL
 Product Version:
-     Reference:   '17.2 (Debian 17.2-1.pgdg120+1)'
-     Target: '16.6 (Debian 16.6-1.pgdg120+1)'
+     Reference:   '17.7 (Debian 17.7-3.pgdg13+1)'
+     Target: '16.13 (Debian 16.13-1.pgdg13+1)'
 Missing Catalog(s): NONE
 Unexpected Catalog(s): NONE
 Changed Catalog(s): NONE
@@ -12,7 +12,7 @@ Missing Check Constraint(s): NONE
 Unexpected Check Constraint(s): NONE
 Changed Check Constraint(s): NONE
 Missing Column(s): NONE
-Unexpected Column(s):
+Unexpected Column(s): 
      public.test_table_for_column.dateColumn
      public.test_view.email
      public.test_view.first_name
@@ -28,13 +28,13 @@ Unexpected Column(s):
      public.test_table_for_column.varcharColumn
 Changed Column(s): NONE
 Missing Composite Type(s): NONE
-Unexpected Composite Type(s):
+Unexpected Composite Type(s): 
      test_diff_type
 Changed Composite Type(s): NONE
 Missing Data Type Attribute(s): NONE
-Unexpected Data Type Attribute(s):
+Unexpected Data Type Attribute(s): 
      public.test_diff_type.attr1
-     public.test_diff_type.attribute3
+     public.test_diff_type.attribute 3
      public.test_diff_type.att®2
 Changed Data Type Attribute(s): NONE
 Missing Database Package(s): NONE
@@ -43,26 +43,25 @@ Changed Database Package(s): NONE
 Missing Database Package Body(s): NONE
 Unexpected Database Package Body(s): NONE
 Changed Database Package Body(s): NONE
+Missing Enum Type(s): NONE
+Unexpected Enum Type(s): NONE
+Changed Enum Type(s): NONE
 Missing Foreign Key(s): NONE
-Unexpected Foreign Key(s):
+Unexpected Foreign Key(s): 
      test_fk(test_table_base[id] -> test_table_reference[test_column])
 Changed Foreign Key(s): NONE
 Missing Function(s): NONE
-Unexpected Function(s):
+Unexpected Function(s): 
      test_function()
      test_function1()
      test_function2()
 Changed Function(s): NONE
 Missing Index(s): NONE
-Unexpected Index(s):
+Unexpected Index(s): 
      idx_first_name ON public.test_table_for_index(id)
-     test_table_base_pkey UNIQUE  ON public.test_table_base(id)
-     test_table_reference_pkey UNIQUE  ON public.test_table_reference(id)
-     test_table_reference_test_column_key UNIQUE  ON public.test_table_reference(test_column)
-     test_unique_constraint UNIQUE  ON public.test_table_for_uc(id)
 Changed Index(s): NONE
 Missing Primary Key(s): NONE
-Unexpected Primary Key(s):
+Unexpected Primary Key(s): 
      test_table_base_pkey on public.test_table_base(id)
      test_table_reference_pkey on public.test_table_reference(id)
 Changed Primary Key(s): NONE
@@ -70,18 +69,18 @@ Missing Schema(s): NONE
 Unexpected Schema(s): NONE
 Changed Schema(s): NONE
 Missing Sequence(s): NONE
-Unexpected Sequence(s):
+Unexpected Sequence(s): 
      test_sequence
 Changed Sequence(s): NONE
 Missing Stored Procedure(s): NONE
-Unexpected Stored Procedure(s):
+Unexpected Stored Procedure(s): 
      test_procedure
 Changed Stored Procedure(s): NONE
 Missing Synonym(s): NONE
 Unexpected Synonym(s): NONE
 Changed Synonym(s): NONE
 Missing Table(s): NONE
-Unexpected Table(s):
+Unexpected Table(s): 
      test_table_base
      test_table_for_column
      test_table_for_index
@@ -89,15 +88,15 @@ Unexpected Table(s):
      test_table_reference
 Changed Table(s): NONE
 Missing Trigger(s): NONE
-Unexpected Trigger(s):
+Unexpected Trigger(s): 
      posts::test_trigger
 Changed Trigger(s): NONE
 Missing Unique Constraint(s): NONE
-Unexpected Unique Constraint(s):
+Unexpected Unique Constraint(s): 
      test_table_reference_test_column_key on test_table_reference(test_column)
      test_unique_constraint on test_table_for_uc(id)
 Changed Unique Constraint(s): NONE
 Missing View(s): NONE
-Unexpected View(s):
+Unexpected View(s): 
      test_view
 Changed View(s): NONE


### PR DESCRIPTION
## Summary

- Refreshes 8 `*-pro.txt` fixtures under `src/main/resources/liquibase/harness/diff/expectedDiff/` so the Advanced workflow's `test (diff)` job stops failing on `expectedDiffContent == generatedDiffContent`.
- The drift is upstream: `liquibase-commercial:master-0bd5478` (used by the workflow since 2026-04-14) fixes [DAT-22909](https://datical.atlassian.net/browse/DAT-22909) — the diff command no longer (a) duplicates PK/UC backing indexes under `Unexpected Index(s)`, and (b) silently drops a non-unique index that shares a column with a primary key. The previous fixtures encoded the pre-fix (buggy) output; this PR brings them in line with the corrected output. Also picks up the new `Missing/Unexpected/Changed Enum Type(s)` triplet now emitted in pro mode.
- mssql and postgres fixtures were regenerated end-to-end against running containers using `master-0bd5478`. mariadb and mysql fixtures were hand-patched (drop the four PK/UC-backing rows from `Unexpected Index(s)`, leaving only `idx_first_name`) — those changelogs don't have a Bug 1 case, so the transformation is mechanical and CI will confirm.
- No harness logic changes. Last green run on this same harness SHA: 2026-04-13 (`master-7d5c982`).

## Test plan

- [ ] Advanced Test Execution workflow `test (diff)` job passes on this branch
- [ ] Spot-check that no other diff-related job regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22909]: https://datical.atlassian.net/browse/DAT-22909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ