### PR TITLE
Add community variant fixture for db2-luw addDefaultValueComputed

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/db2-luw/addDefaultValueComputed-community.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/db2-luw/addDefaultValueComputed-community.json
@@ -1,0 +1,18 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "defaultValue": "CURRENT DATE",
+            "name": "INSERTED_DATE",
+            "nullable": true,
+            "type": {
+              "typeName": "DATE"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `addDefaultValueComputed-community.json` for db2-luw with the plain `"CURRENT DATE"` form, so community Liquibase runs match what the OSS snapshot path actually emits.
- The existing `addDefaultValueComputed.json` (wrapped `CURRENT DATE!{liquibase.statement.DatabaseFunction}` form, introduced in #1262 / INT-1602) is left in place for Pro runs.
- No code changes required: `FileUtils.getFileContent` already prefers `*-community.json` variants when `useProArtifacts != "true"`.

## Why
The db2-luw fixture was bumped in #1262 to expect the `DatabaseFunction`-wrapped form, which matches the Pro snapshot fast-path (`ProJdbcDatabaseSnapshot` / `ProDatabaseObjectCollection` from liquibase-pro DAT-22307). Community Liquibase emits a plain string `"CURRENT DATE"`, so workflow-dispatch runs against community SHAs (e.g. [run 25517206802](https://github.com/liquibase/liquibase-test-harness/actions/runs/25517206802/job/74891579894)) fail with:

```
liquibase.harness.LiquibaseHarnessSuiteTest.apply addDefaultValueComputed against db2-luw 11.5.7
  snapshot.objects.liquibase.structure.core.Column[0] Could not find match for element
  {"column":{"defaultValue":"CURRENT DATE!{liquibase.statement.DatabaseFunction}", ...}}
```

The same `-community` split pattern is already used for `sqlite/addDefaultValueNumeric-community.json`.

## Test plan
- [ ] Re-run the Default Test Execution workflow on a community SHA (the SHA from [liquibase@ba0b5bde](https://github.com/liquibase/liquibase/commit/ba0b5bde6d1be18630fad5d5c3f166d2245a8dce) reproduces the failure today) and confirm db2-luw now passes.
- [ ] Re-run a Pro/scheduled main run and confirm db2-luw still passes against the unchanged Pro fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)