### PR TITLE
TECHOPS-154: replace stale whatnick/wait-action with sleep

### DIFF
--- a/.github/workflows/OracleRunParallel.yml
+++ b/.github/workflows/OracleRunParallel.yml
@@ -65,9 +65,7 @@ jobs:
 
       # Adding sleep to avoid ORA-12514 error when database & listeners are still in the middle of startup
       - name: Sleep for 180 seconds
-        uses: whatnick/wait-action@71008d68ab3939de1475f4938583e4480b5d09a6 # v0.1.2
-        with:
-          time: "180s"
+        run: sleep 180
 
       - name: Oracle ${{ matrix.plan }} Test Run
         run: |


### PR DESCRIPTION
## Summary

Replace stale `whatnick/wait-action@v0.1.2` (last push 2020-07-23, ~6 years ago) with the shell builtin. Resolves [TECHOPS-154](https://datical.atlassian.net/browse/TECHOPS-154), unblocks DAT-22654 allowlist cleanup.

## What changed

`OracleRunParallel.yml` — the Sleep step:

| Before | After |
|---|---|
| `uses: whatnick/wait-action@…71008d68… # v0.1.2` with `time: "180s"` | `run: sleep 180` |

## Test plan

- [ ] Workflow YAML parses
- [ ] Next nightly Oracle parallel run waits 180s before invoking the test step (same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-154]: https://datical.atlassian.net/browse/TECHOPS-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ