### PR TITLE
feat(ci): notify Slack on test-harness workflow failures [TECHOPS-454]

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -24,6 +24,17 @@ on:
       - "Oracle Parallel Test Execution"            # OracleRunParallel.yml
     types:
       - completed
+  # Manual dispatch for end-to-end testing. Pass a known failed-run id of any
+  # of the upstream workflows; the notifier will fetch its metadata + jobs
+  # and post the real-shape payload to Slack. Useful for confirming vault
+  # wiring, webhook URL, channel routing, and message rendering without
+  # waiting for the next real failure.
+  workflow_dispatch:
+    inputs:
+      test_run_id:
+        description: "Workflow run ID to use as the test target (must be a run of one of the upstream workflows above)"
+        required: true
+        type: string
 
 permissions:
   actions: read     # listJobsForWorkflowRun
@@ -34,8 +45,10 @@ jobs:
   notify:
     name: Post failure to Slack
     # workflow_run.conclusion is one of: success, failure, cancelled,
-    # timed_out, action_required, neutral, skipped, stale.
+    # timed_out, action_required, neutral, skipped, stale. Manual dispatch
+    # always runs (it is the test path).
     if: >-
+      github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'failure' ||
       github.event.workflow_run.conclusion == 'timed_out' ||
       github.event.workflow_run.conclusion == 'cancelled'
@@ -61,10 +74,32 @@ jobs:
         # a file and consuming via payload-file-path keeps the Slack action's
         # templating off, eliminating any expression-injection vector.
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TEST_RUN_ID: ${{ github.event.inputs.test_run_id }}
         with:
           script: |
             const fs = require('fs');
-            const run = context.payload.workflow_run;
+
+            // Two entry paths:
+            //   - workflow_run event: real upstream failure, payload.workflow_run is set
+            //   - workflow_dispatch event: test mode, fetch the run by id via API
+            let run;
+            if (context.eventName === 'workflow_dispatch') {
+              const runId = process.env.TEST_RUN_ID;
+              if (!runId) {
+                core.setFailed('workflow_dispatch requires test_run_id input');
+                return;
+              }
+              core.info(`Test mode — fetching run ${runId}`);
+              const { data } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: parseInt(runId, 10),
+              });
+              run = data;
+            } else {
+              run = context.payload.workflow_run;
+            }
 
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner: context.repo.owner,

--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -1,0 +1,153 @@
+name: Notify Slack on Workflow Failure
+
+# Central failure-notifier for the test-harness CI workflows. Triggers on the
+# completion of the upstream workflows below and posts to Slack only when the
+# upstream run ended in failure, timed_out, or cancelled. Success runs stay
+# silent to keep signal-to-noise high. See TECHOPS-454 for rationale.
+#
+# Visual style mirrors liquibase/liquibase dry-run-release.yml: a danger-colored
+# Slack attachment wrapping a Block Kit body, so the message has the red
+# left-bar plus modern structured content. Webhook is loaded from /vault/liquibase
+# via OIDC, same pattern as every other cloud workflow in this repo.
+
+on:
+  workflow_run:
+    # Match by upstream workflow `name:` field, not filename.
+    workflows:
+      - "Default Test Execution"                    # main.yml
+      - "Advanced Test Execution"                   # advanced.yml
+      - "AWS Cloud Database Test Execution"         # aws.yml
+      - "AWS Weekly Cloud Database Test Execution"  # aws-weekly.yml
+      - "Azure Cloud Sql DB Test"                   # azure.yml
+      - "Google Cloud Database Test Execution"      # gcp.yml
+      - "Oracle OCI Test Execution"                 # oracle-oci.yml
+      - "Oracle Parallel Test Execution"            # OracleRunParallel.yml
+    types:
+      - completed
+
+permissions:
+  actions: read     # listJobsForWorkflowRun
+  contents: read
+  id-token: write   # OIDC for AWS vault access
+
+jobs:
+  notify:
+    name: Post failure to Slack
+    # workflow_run.conclusion is one of: success, failure, cancelled,
+    # timed_out, action_required, neutral, skipped, stale.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out' ||
+      github.event.workflow_run.conclusion == 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Build Slack payload
+        id: build-payload
+        # Build the payload in JS so user-controlled fields (commit author
+        # name, branch name, etc.) are JSON-escaped automatically. Writing to
+        # a file and consuming via payload-file-path keeps the Slack action's
+        # templating off, eliminating any expression-injection vector.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const run = context.payload.workflow_run;
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+              per_page: 100,
+            });
+            const failedJobs = jobs
+              .filter(j => ['failure', 'timed_out', 'cancelled'].includes(j.conclusion))
+              .map(j => `• <${j.html_url}|${j.name}>`);
+            const failedList = failedJobs.length
+              ? failedJobs.join('\n')
+              : '_no individual job marked failed — check the full run log_';
+
+            const author = (run.head_commit && run.head_commit.author && run.head_commit.author.name) || 'unknown';
+            const sha = (run.head_sha || '').slice(0, 7);
+            const fullSha = run.head_sha || '';
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const commitUrl = `${context.serverUrl}/${repo}/commit/${fullSha}`;
+            const branchUrl = `${context.serverUrl}/${repo}/tree/${encodeURIComponent(run.head_branch || '')}`;
+
+            // Outer attachment carries the danger color (red sidebar).
+            // Inner blocks carry the structured content.
+            const payload = {
+              username: 'test-harness-alerts',
+              icon_emoji: ':rotating_light:',
+              text: `:x: ${run.name} ${run.conclusion} on ${run.head_branch} — ${repo}`,
+              attachments: [
+                {
+                  color: 'danger',
+                  fallback: `${run.name} ${run.conclusion} on ${run.head_branch}`,
+                  blocks: [
+                    {
+                      type: 'header',
+                      text: { type: 'plain_text', text: `:x:  ${run.name}`, emoji: true },
+                    },
+                    {
+                      type: 'context',
+                      elements: [
+                        { type: 'mrkdwn', text: `:gear: \`${repo}\` • run #${run.run_number} • attempt ${run.run_attempt}` },
+                      ],
+                    },
+                    {
+                      type: 'section',
+                      fields: [
+                        { type: 'mrkdwn', text: `*Conclusion*\n\`${run.conclusion}\`` },
+                        { type: 'mrkdwn', text: `*Event*\n\`${run.event}\`` },
+                        { type: 'mrkdwn', text: `*Branch*\n<${branchUrl}|\`${run.head_branch}\`>` },
+                        { type: 'mrkdwn', text: `*Commit*\n<${commitUrl}|\`${sha}\`> by ${author}` },
+                      ],
+                    },
+                    { type: 'divider' },
+                    {
+                      type: 'section',
+                      text: { type: 'mrkdwn', text: `*Failed jobs*\n${failedList}` },
+                    },
+                    {
+                      type: 'actions',
+                      elements: [
+                        {
+                          type: 'button',
+                          text: { type: 'plain_text', text: ':mag: Open failed run', emoji: true },
+                          url: run.html_url,
+                          style: 'danger',
+                        },
+                        {
+                          type: 'button',
+                          text: { type: 'plain_text', text: ':octocat: View commit', emoji: true },
+                          url: commitUrl,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            };
+
+            fs.writeFileSync(`${process.env.RUNNER_TEMP}/slack-payload.json`, JSON.stringify(payload));
+            core.setOutput('path', `${process.env.RUNNER_TEMP}/slack-payload.json`);
+
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ env.TEST_HARNESS_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-file-path: ${{ steps.build-payload.outputs.path }}

--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -5,10 +5,6 @@ name: Notify Slack on Workflow Failure
 # upstream run ended in failure, timed_out, or cancelled. Success runs stay
 # silent to keep signal-to-noise high. See TECHOPS-454 for rationale.
 #
-# Visual style mirrors liquibase/liquibase dry-run-release.yml: a danger-colored
-# Slack attachment wrapping a Block Kit body, so the message has the red
-# left-bar plus modern structured content. Webhook is loaded from /vault/liquibase
-# via OIDC, same pattern as every other cloud workflow in this repo.
 
 on:
   workflow_run:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Extensions that add support for additional databases and/or define additional fu
 
 The test harness is configured to run via GitHub Actions workflows with smart artifact selection based on the triggering repository.
 
+#### Failure Notifications
+
+Failures from the test-harness CI workflows (`main`, `advanced`, `aws`, `aws-weekly`, `azure`, `gcp`, `oracle-oci`, `OracleRunParallel`) post to the **#test-harness-alerts** Slack channel. The notifier is a separate `workflow_run`-triggered workflow ([`.github/workflows/notify-slack-on-failure.yml`](.github/workflows/notify-slack-on-failure.yml)) that listens to the eight workflows above and posts only on `failure`, `timed_out`, or `cancelled` conclusions — success runs stay silent. Each message includes the workflow name, branch/ref, triggering event, commit SHA + author, the list of failed jobs, and a direct link to the run.
+
+To mute or change routing, edit `notify-slack-on-failure.yml` or the channel-side Slack subscription. The webhook URL is stored in AWS Secrets Manager under `/vault/liquibase` (key `TEST_HARNESS_SLACK_WEBHOOK`) and loaded into the workflow via OIDC, the same pattern as every other cloud workflow in this repo.
+
 #### Repository-Aware Artifact Selection
 
 Starting with the Liquibase Secure release, the **main.yml** workflow automatically detects which repository triggered it and selects appropriate artifacts:


### PR DESCRIPTION
## Summary

Adds a central failure-notifier workflow (`.github/workflows/notify-slack-on-failure.yml`) that listens via `workflow_run` to the eight test-harness CI workflows and posts to **#test-harness-alerts** when any of them ends in `failure`, `timed_out`, or `cancelled`. Success runs stay silent.

Workflows in scope (all 8 from the ticket):

| Workflow file | `name:` (what `workflow_run` matches on) | Trigger events |
|---|---|---|
| `main.yml` | Default Test Execution | push, pull_request, schedule, workflow_dispatch, repository_dispatch |
| `advanced.yml` | Advanced Test Execution | schedule, workflow_dispatch, repository_dispatch |
| `aws.yml` | AWS Cloud Database Test Execution | schedule, workflow_dispatch, repository_dispatch |
| `aws-weekly.yml` | AWS Weekly Cloud Database Test Execution | schedule, workflow_dispatch |
| `azure.yml` | Azure Cloud Sql DB Test | schedule, workflow_dispatch, repository_dispatch |
| `gcp.yml` | Google Cloud Database Test Execution | schedule, workflow_dispatch, repository_dispatch |
| `oracle-oci.yml` | Oracle OCI Test Execution | schedule, workflow_dispatch, repository_dispatch |
| `OracleRunParallel.yml` | Oracle Parallel Test Execution | schedule, workflow_dispatch |

## What the Slack post looks like

Mirrors the style of [liquibase/liquibase dry-run-release.yml](https://github.com/liquibase/liquibase/blob/main/.github/workflows/dry-run-release.yml) — a danger-colored attachment (red sidebar) wrapping a Block Kit body:

- **Header**: `:x:  <workflow name>`
- **Context row**: `:gear: <repo> • run #<N> • attempt <M>`
- **Four fields**: Conclusion / Event / Branch / Commit (with author)
- **Failed jobs**: bulleted list, each item links to the job's own page
- **Two buttons**: red "Open failed run" + neutral "View commit"
- **Username / icon**: `test-harness-alerts` / `:rotating_light:` so the source is visually distinct in-channel

## Design choices and why

| Choice | Why |
|---|---|
| Single `workflow_run` notifier file | Ticket-recommended option; one place to evolve message format instead of 8. |
| Webhook from `/vault/liquibase` via OIDC | Matches every other cloud workflow in this repo (`oracle-oci.yml`, `aws.yml`, etc.) — no new credential mechanism. |
| Payload built in `github-script`, consumed via `payload-file-path` | User-controlled fields (commit author name, branch name) get JSON-escaped automatically. No expression interpolation into the JSON body → no injection vector through `workflow_run` fields. |
| Failed-job names from `listJobsForWorkflowRun` | Per-job conclusion is more accurate than the whole-run conclusion; lets the message link directly to the failing job's log. |
| Action pins (SHA + version comment) | Follows the [DAT-22656 immutable-SHA convention](https://github.com/liquibase/liquibase-test-harness/blob/main/.github/workflows/oracle-oci.yml) already in this repo: `actions/github-script v9.0.0`, `slackapi/slack-github-action v3.0.3`, `aws-actions/aws-secretsmanager-get-secrets v3.0.1`; AWS credential config via `liquibase/build-logic` composite. |

## Prerequisites — must land before this is useful

- [ ] Slack channel **#test-harness-alerts** created and team members invited.
- [ ] Slack App `Test Harness Alerts` installed to the workspace with Incoming Webhooks enabled, webhook scoped to #test-harness-alerts.
- [ ] Webhook URL stored in AWS Secrets Manager at `/vault/liquibase` under the JSON key `TEST_HARNESS_SLACK_WEBHOOK`. (The `aws-secretsmanager-get-secrets` action with `parse-json-secrets: true` will surface it as the env var with the same uppercase name.)

Until those land, the notifier merges harmlessly: `workflow_run` fires, the `slackapi/slack-github-action` step gets an empty `webhook:` and errors out, but no upstream CI is affected (this notifier is a downstream consumer, not a gating job).

## Caveats reviewers should know

- **`workflow_run` only fires when the notifier file is on the default branch.** This PR's own CI won't exercise the notifier; the first real activation is the next post-merge upstream failure.
- **PR notifications come only from `main.yml`** because that's the only workflow of the eight with a `pull_request:` trigger. The other 7 are scheduled/dispatch-only — the primary value of this PR is **catching scheduled-cron failures**, which is the use case that drove [TECHOPS-454](https://datical.atlassian.net/browse/TECHOPS-454) (and which the 90-day [TECHOPS-448](https://datical.atlassian.net/browse/TECHOPS-448) outage perfectly illustrates the cost of).
- **No filter on `head_branch`** — failures on any branch produce a Slack post. If the channel turns out noisy from WIP PRs failing `main.yml` repeatedly, the easiest mitigation is to add `&& github.event.workflow_run.head_branch == 'main'` to the job-level `if:` (or filter on event type) in a follow-up rather than over-filter now.

## Test plan

- [ ] Local: `actionlint .github/workflows/notify-slack-on-failure.yml` passes (confirmed before push).
- [ ] After merge: re-trigger a known-failing workflow (e.g. `gh workflow run oracle-oci.yml`) and confirm a Slack post lands in #test-harness-alerts with the expected fields populated.
- [ ] Visual: verify the danger sidebar, header, four fields, failed-jobs section, and both buttons render as intended in Slack.
- [ ] Click both buttons and confirm they deep-link to the failed run page and the commit page.

Closes TECHOPS-454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-454]: https://datical.atlassian.net/browse/TECHOPS-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ