### PR TITLE
[TECHOPS-460] Pilot: route mysql:aws init through SSM tunnel

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           set -euo pipefail
           apt-get update
-          apt-get install -y --no-install-recommends netcat-openbsd unzip ca-certificates
+          apt-get install -y --no-install-recommends netcat-openbsd unzip ca-certificates sudo
           if ! command -v aws >/dev/null 2>&1; then
             curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscli.zip
             unzip -q /tmp/awscli.zip -d /tmp

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -58,6 +58,7 @@ jobs:
     needs: [deploy-ephemeral-cloud-infra, setup]
     container:
       image: liquibase/liquibase:latest
+      options: --user root
     strategy:
       fail-fast: false
       matrix:
@@ -142,6 +143,22 @@ jobs:
           echo "host=$host"     >> "$GITHUB_OUTPUT"
           echo "port=$port"     >> "$GITHUB_OUTPUT"
           echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Install AWS CLI and netcat
+        if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends netcat-openbsd unzip ca-certificates
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscli.zip
+            unzip -q /tmp/awscli.zip -d /tmp
+            /tmp/aws/install
+            rm -rf /tmp/awscli.zip /tmp/aws
+          fi
+          aws --version
+          command -v nc
 
       - name: Open SSM tunnel to MySQL
         if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -144,8 +144,7 @@ jobs:
 
       - name: Open SSM tunnel to MySQL
         if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
-        # TODO TECHOPS-460: switch to @main after liquibase/build-logic#595 merges.
-        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@TECHOPS-460-ssm-db-tunnel
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@main
         with:
           bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
           db-host: ${{ steps.parse-mysql.outputs.host }}

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -126,6 +126,7 @@ jobs:
         if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
         env:
           JDBC_URL: ${{ env.TH_MYSQLURL_8_0 }}
+        shell: bash
         run: |
           set -euo pipefail
           # JDBC URL shape: jdbc:mysql://<host>:<port>/<dbname>[?...]

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           secret-ids: |
             TH_MYSQLURL_8_0, /testautomation/db_details/aws_mysql_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+            SSM_BASTION_INSTANCE_ID, /testautomation/ssm/bastion_instance_id
       - name: Get AWS secrets
         if: ${{ matrix.version == 'aurora' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
         uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
@@ -116,11 +117,47 @@ jobs:
       - name: Install Dependencies
         run: lpm update && lpm add mysql
 
+      # TECHOPS-460 pilot: route the mysql:aws init through an SSM port-forwarding
+      # tunnel to the test-automation bastion so the RDS instance can move to
+      # publicly_accessible=false. The MySQL JDBC URL is rewritten to point at
+      # localhost; everything else (auth, changelog, db name) is unchanged.
+      - name: Parse MySQL endpoint from JDBC URL
+        id: parse-mysql
+        if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
+        env:
+          JDBC_URL: ${{ env.TH_MYSQLURL_8_0 }}
+        run: |
+          set -euo pipefail
+          # JDBC URL shape: jdbc:mysql://<host>:<port>/<dbname>[?...]
+          host_port="${JDBC_URL#jdbc:mysql://}"
+          host_port="${host_port%%/*}"
+          host="${host_port%%:*}"
+          port="${host_port##*:}"
+          dbname_qs="${JDBC_URL##*/}"
+          if [[ ! "$host" =~ ^[A-Za-z0-9.-]+$ ]] || [[ ! "$port" =~ ^[0-9]{1,5}$ ]]; then
+            echo "::error::Could not parse host/port from JDBC URL" >&2
+            exit 1
+          fi
+          echo "host=$host"     >> "$GITHUB_OUTPUT"
+          echo "port=$port"     >> "$GITHUB_OUTPUT"
+          echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Open SSM tunnel to MySQL
+        if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
+        # TODO TECHOPS-460: switch to @main after liquibase/build-logic#595 merges.
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@TECHOPS-460-ssm-db-tunnel
+        with:
+          bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
+          db-host: ${{ steps.parse-mysql.outputs.host }}
+          db-port: ${{ steps.parse-mysql.outputs.port }}
+          local-port: '13306'
+
       - name: Init Database
         if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-        run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}_cloud.sql" --username="${{ env.TH_DB_ADMIN }}" --password="${{ env.TH_DB_PASSWD }}" --url="${{ env.TH_MYSQLURL_8_0 }}" update
+          TUNNELED_MYSQL_URL: jdbc:mysql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-mysql.outputs.dbname-qs }}
+        run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}_cloud.sql" --username="${{ env.TH_DB_ADMIN }}" --password="${{ env.TH_DB_PASSWD }}" --url="${{ env.TUNNELED_MYSQL_URL }}" update
 
       - name: Init Database
         if: ${{ matrix.version == 'aurora' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}


### PR DESCRIPTION
## Summary

Pilot conversion of the **`mysql:aws`** init step in `aws-weekly.yml` to use AWS Systems Manager Session Manager port forwarding via the new build-logic composite action. This is PR 3 of N for the TECHOPS-460 multi-repo rollout to make test-automation RDS instances private (`publicly_accessible = false`) without requiring self-hosted GitHub runners.

**Scope is intentionally narrow:** only the `database=mysql, version=aws` path in the `init-mysql` job is modified. Aurora, postgres, oracle, mariadb, mssql paths are untouched and continue to use direct public connections. Once this pilot validates green for a couple of nightly runs, the same pattern can be applied to the other DBs one at a time (and only then will the matching RDS modules flip private in `liquibase-infrastructure`).

## What changes

For the pilot path, four small additions before the existing `Init Database` step:

1. **`Get AWS secrets`** also fetches `/testautomation/ssm/bastion_instance_id` into `SSM_BASTION_INSTANCE_ID`.
2. **`Parse MySQL endpoint from JDBC URL`** extracts `host`, `port`, and the dbname-plus-querystring tail out of `TH_MYSQLURL_8_0`.
3. **`Open SSM tunnel to MySQL`** invokes the new composite action `liquibase/build-logic/.github/actions/ssm-db-tunnel`, which starts a background `aws ssm start-session --document-name AWS-StartPortForwardingSessionToRemoteHost` and exports `TUNNELED_DB_HOST=localhost` / `TUNNELED_DB_PORT=13306` to `$GITHUB_ENV`.
4. **`Init Database`** now uses a rewritten JDBC URL: `jdbc:mysql://${TUNNELED_DB_HOST}:${TUNNELED_DB_PORT}/<original dbname>`. All other args (username, password, classpath, changelog) are unchanged.

## Why a pilot, why mysql:aws

The reusable workflow `ephemeral-cloud-infra.yml` in `liquibase/build-logic` already provisions the RDS instances and emits a `resources_id`. The mysql:aws path is the simplest to convert because it has a single dedicated init step in `aws-weekly.yml`, no special drivers, and parses cleanly out of one JDBC URL. If this pilot is green for two weekly runs, the same change is mechanical for the other DBs.

## Dependencies (must merge in this order)

1. [liquibase-infrastructure#3715](https://github.com/liquibase/liquibase-infrastructure/pull/3715) creates the bastion in the test-automation VPC and writes its EC2 instance ID to `/testautomation/ssm/bastion_instance_id` in AWS Secrets Manager.
2. [liquibase/build-logic#595](https://github.com/liquibase/build-logic/pull/595) ships the `ssm-db-tunnel` composite action.
3. **This PR** (`liquibase-test-harness#TBD`): the workflow currently pins the action to `@TECHOPS-460-ssm-db-tunnel` (the branch on build-logic) so the validator can resolve it. After build-logic#595 merges, a follow-up commit will switch it to `@main`.

The bastion already permits egress to port 3306, so once #3715 is applied the tunnel will reach the existing `aws_mysql` instance even while it remains publicly accessible. That's intentional for the pilot: we validate the tunnel path *first*, then flip the DB module in a separate liquibase-infrastructure PR.

## Test plan

- [ ] After #3715 applies in dev, manually trigger this workflow with `databases=[\"mysql:aws\"]` and confirm the `init-mysql` job for the `aws` matrix entry runs the tunnel step, the JDBC URL points at `localhost:13306`, and the liquibase `update` succeeds.
- [ ] The first scheduled `aws-weekly.yml` run after merge is green (the mysql:aws matrix entry, plus all the other unchanged matrix entries).
- [ ] No regression in the aurora-mysql path or any other DB.

If the pilot is solid, follow-up PRs do:
1. Same pattern for the other DBs (one per PR, validated by the next scheduled run).
2. In `liquibase-infrastructure`, flip `publicly_accessible = false` on the matching `test-automation/aws-*` module after its DB's pilot run is green.

## Out of scope

- The `aws.yml` workflow (daily). Same conversion pattern but the weekly is simpler to validate first.
- All DBs other than `mysql:aws`.

IAM permissions on `github-actions-build-logic` for `ssm:StartSession` / `ssm:TerminateSession` / `ssm:DescribeInstanceInformation` are handled in the dependency PR [liquibase-infrastructure#3715](https://github.com/liquibase/liquibase-infrastructure/pull/3715) via the new `test-automation/aws-ssm-bastion-iam.tf`. The role also has `ssm:*` on `*` in the dev-account stack today; the explicit scoped grant exists for clarity in PR review.

Refs: TECHOPS-460, [liquibase-infrastructure#3715](https://github.com/liquibase/liquibase-infrastructure/pull/3715), [liquibase/build-logic#595](https://github.com/liquibase/build-logic/pull/595)
