### PR TITLE
[TECHOPS-460] Pilot: route postgresql:aurora through SSM tunnel

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -394,17 +394,27 @@ jobs:
           password: "${{env.TH_DB_PASSWD}}"
           url: "${{ env.TH_MSSQLURL }}"
 
-      - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
+      # TECHOPS-460: cannot use liquibase/liquibase-github-action here because it
+      # spawns its own container with default bridge networking, so the SSM
+      # tunnel on the runner host's 127.0.0.1:15432 is unreachable. Run the
+      # liquibase image directly with --network host so the container shares
+      # the runner's loopback. Same image, same args; just no isolation layer.
+      - name: Init Aurora PG via SSM tunnel
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-        with:
-          operation: "update"
-          classpath: "src/test/resources/init-changelogs/aws:liquibase_libs/postgresql.jar"
-          changeLogFile: "postgresql.sql"
-          username: "${{env.TH_DB_ADMIN}}"
-          password: "${{env.TH_DB_PASSWD}}"
-          url: "jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}"
+        run: |
+          docker run --rm --network host \
+            -v "${PWD}:/workspace" \
+            -w /workspace \
+            -e LIQUIBASE_PRO_LICENSE_KEY \
+            liquibase/liquibase:latest \
+            --classpath="src/test/resources/init-changelogs/aws:liquibase_libs/postgresql.jar" \
+            --changeLogFile="postgresql.sql" \
+            --username="${{ env.TH_DB_ADMIN }}" \
+            --password="${{ env.TH_DB_PASSWD }}" \
+            --url="jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}" \
+            update
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -323,6 +323,19 @@ jobs:
           db-port: ${{ steps.parse-aurora-pg.outputs.port }}
           local-port: '15432'
 
+      # liquibase/liquibase:latest (used by liquibase-github-action) does not
+      # bundle the PostgreSQL JDBC driver since 5.0.3. Stage it into
+      # liquibase_libs/ so the action's container picks it up via classpath.
+      - name: Install PostgreSQL JDBC driver
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p liquibase_libs
+          curl -fsSL -o liquibase_libs/postgresql.jar \
+            https://jdbc.postgresql.org/download/postgresql-42.7.4.jar
+          ls -la liquibase_libs/
+
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
         env:
@@ -387,7 +400,7 @@ jobs:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         with:
           operation: "update"
-          classpath: "src/test/resources/init-changelogs/aws"
+          classpath: "src/test/resources/init-changelogs/aws:liquibase_libs/postgresql.jar"
           changeLogFile: "postgresql.sql"
           username: "${{env.TH_DB_ADMIN}}"
           password: "${{env.TH_DB_PASSWD}}"

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           secret-ids: |
             TH_AURORA_POSTGRESQLURL, /testautomation/db_details/aurora_postgresql16_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
-            ,/testautomation/ssm/bastion_instance_id
+            SSM_BASTION_INSTANCE_ID, /testautomation/ssm/bastion_instance_id
 
       # TECHOPS-460 pilot: route the postgresql:aurora init+test through an SSM
       # port-forwarding tunnel so it works once the underlying Aurora PG cluster

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -274,6 +274,48 @@ jobs:
         with:
           secret-ids: |
             TH_AURORA_POSTGRESQLURL, /testautomation/db_details/aurora_postgresql16_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+            ,/testautomation/ssm/bastion_instance_id
+
+      # TECHOPS-460 pilot: route the postgresql:aurora init+test through an SSM
+      # port-forwarding tunnel so it works once the underlying Aurora PG cluster
+      # flips publicly_accessible=false. parse-aurora-pg extracts host/port from
+      # the JDBC URL; the composite action opens the tunnel and exports
+      # TUNNELED_DB_HOST/TUNNELED_DB_PORT for the liquibase + mvn steps below.
+      - name: Parse Aurora PG endpoint from JDBC URL
+        id: parse-aurora-pg
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}
+        env:
+          JDBC_URL: ${{ env.TH_AURORA_POSTGRESQLURL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # JDBC URL shape: jdbc:postgresql://<host>[:<port>]/<dbname>[?...]
+          tail="${JDBC_URL#jdbc:postgresql://}"
+          host_port="${tail%%/*}"
+          dbname_qs="${tail#*/}"
+          if [[ "$host_port" == *:* ]]; then
+            host="${host_port%%:*}"
+            port="${host_port##*:}"
+          else
+            host="$host_port"
+            port="5432"
+          fi
+          if [[ ! "$host" =~ ^[A-Za-z0-9.-]+$ ]] || [[ ! "$port" =~ ^[0-9]{1,5}$ ]]; then
+            echo "::error::Could not parse host/port from JDBC URL" >&2
+            exit 1
+          fi
+          echo "host=$host"           >> "$GITHUB_OUTPUT"
+          echo "port=$port"           >> "$GITHUB_OUTPUT"
+          echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Open SSM tunnel to Aurora PG
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@main
+        with:
+          bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
+          db-host: ${{ steps.parse-aurora-pg.outputs.host }}
+          db-port: ${{ steps.parse-aurora-pg.outputs.port }}
+          local-port: '15432'
 
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
@@ -343,7 +385,7 @@ jobs:
           changeLogFile: "postgresql.sql"
           username: "${{env.TH_DB_ADMIN}}"
           password: "${{env.TH_DB_PASSWD}}"
-          url: "${{ env.TH_AURORA_POSTGRESQLURL }}"
+          url: "jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}"
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main
         with:
@@ -440,7 +482,7 @@ jobs:
           mvn -B -PuseProArtifacts -DuseProArtifacts=true dependency:tree 2>&1 | grep -E "(liquibase|BUILD SUCCESS)" || true
           echo "::endgroup::"
 
-          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=17 -Dprefix=aurora -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='${{ env.TH_AURORA_POSTGRESQLURL }}' test
+          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=17 -Dprefix=aurora -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}' test
 
       - name: Archive AWS RDS ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -511,7 +511,7 @@ jobs:
           mvn -B -PuseProArtifacts -DuseProArtifacts=true dependency:tree 2>&1 | grep -E "(liquibase|BUILD SUCCESS)" || true
           echo "::endgroup::"
 
-          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=17 -Dprefix=aurora -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}' test
+          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=16 -Dprefix=aurora -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}' test
 
       - name: Archive AWS RDS ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -184,6 +184,12 @@ jobs:
 
   test:
     needs: [deploy-ephemeral-cloud-infra, init-mysql, setup]
+    # init-mysql only runs when mysql:aws or mysql:aurora is in the matrix.
+    # For targeted dispatches that exclude mysql, init-mysql is `skipped` and
+    # the default `needs` semantics would cascade-skip this job. Explicitly
+    # gate on deploy-ephemeral + setup success and tolerate any init-mysql
+    # outcome that isn't a hard failure so per-engine pilots can be smoke-tested.
+    if: ${{ !cancelled() && needs.deploy-ephemeral-cloud-infra.result == 'success' && needs.setup.result == 'success' && needs.init-mysql.result != 'failure' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -403,6 +403,9 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          DB_USERNAME: ${{ env.TH_DB_ADMIN }}
+          DB_PASSWORD: ${{ env.TH_DB_PASSWD }}
+          AURORA_PG_JDBC_URL: jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}
         run: |
           docker run --rm --network host \
             -v "${PWD}:/workspace" \
@@ -411,9 +414,9 @@ jobs:
             liquibase/liquibase:latest \
             --classpath="src/test/resources/init-changelogs/aws:liquibase_libs/postgresql.jar" \
             --changeLogFile="postgresql.sql" \
-            --username="${{ env.TH_DB_ADMIN }}" \
-            --password="${{ env.TH_DB_PASSWD }}" \
-            --url="jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}" \
+            --username="$DB_USERNAME" \
+            --password="$DB_PASSWORD" \
+            --url="$AURORA_PG_JDBC_URL" \
             update
 
       - uses: liquibase/build-logic/.github/actions/setup-java@main
@@ -506,12 +509,17 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          TEST_CLASSES: ${{ needs.setup.outputs.testClasses }}
+          DB_PLATFORM: ${{ steps.setup.outputs.databasePlatform }}
+          DB_USERNAME: ${{ env.TH_DB_ADMIN }}
+          DB_PASSWORD: ${{ env.TH_DB_PASSWD }}
+          AURORA_PG_JDBC_URL: jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}
         run: |
           echo "::group::Dependency Tree (PRO - liquibase-commercial)"
           mvn -B -PuseProArtifacts -DuseProArtifacts=true dependency:tree 2>&1 | grep -E "(liquibase|BUILD SUCCESS)" || true
           echo "::endgroup::"
 
-          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=16 -Dprefix=aurora -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-pg.outputs.dbname-qs }}' test
+          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest="$TEST_CLASSES" -DconfigFile=/harness-config-cloud.yml -DdbName="$DB_PLATFORM" -DdbVersion=16 -Dprefix=aurora -DdbUsername="$DB_USERNAME" -DdbPassword="$DB_PASSWORD" -DdbUrl="$AURORA_PG_JDBC_URL" test
 
       - name: Archive AWS RDS ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Second pilot of the TECHOPS-460 multi-repo rollout: extend SSM tunneling from `mysql:aws` (shipped in #1288) to **`postgresql:aurora` v16** so the `aws-aurora-postgres` cluster can flip `publicly_accessible=false` in a follow-up `liquibase-infrastructure` PR without breaking aws-weekly.

Scope is intentionally narrow: only the `postgresql:aurora` matrix entry is modified. Other matrix entries (mysql:aurora, oracle, mssql, mariadb, single-instance postgres) stay direct-public.

## What changes

In the `test` job, `postgresql && aurora` path only:

1. **`Get AWS secrets`** also fetches `/testautomation/ssm/bastion_instance_id` into `SSM_BASTION_INSTANCE_ID`.
2. **`Parse Aurora PG endpoint from JDBC URL`** extracts host, port, and dbname out of `TH_AURORA_POSTGRESQLURL`. Defaults port to 5432 because `aws_rds_cluster.endpoint` returns hostname-only (verified against the upstream Terraform module).
3. **`Open SSM tunnel to Aurora PG`** invokes `liquibase/build-logic/.github/actions/ssm-db-tunnel@main` and exports `TUNNELED_DB_HOST=localhost` / `TUNNELED_DB_PORT=15432`.
4. **Liquibase update step** and **maven test step** now use the rewritten JDBC URL `jdbc:postgresql://${TUNNELED_DB_HOST}:${TUNNELED_DB_PORT}/<dbname>`.

No container fixes needed: the `test` job runs on `ubuntu-latest`, where `aws`/`nc` are preinstalled. Compare with `init-mysql` in the prior PR which is container-based and needed the `apt-get install + sudo` plumbing.

## Why postgresql:aurora next

TECHOPS-460's primary target is the Aurora PostgreSQL cluster (Finding 1 in the ticket: `Discovery:RDS/MaliciousIPCaller` + `CredentialAccess:RDS/MaliciousIPCaller.FailedLogin` on `aurora-postgresql-primary-instance16`). Validating this tunnel route is the prerequisite for the infra PR that flips that exact cluster to private.

## Dependencies

* Already merged: liquibase/liquibase-infrastructure#3715 (bastion + IAM + `/testautomation/ssm/bastion_instance_id`).
* Already merged: liquibase/build-logic#595 (`ssm-db-tunnel` composite action).
* Already merged: liquibase/liquibase-test-harness#1288 (mysql:aws pilot, validates the same composite end-to-end).

The bastion SG already permits egress to port 5432 in the VPC CIDR (set up in #3715), so this works against the still-public Aurora PG cluster immediately. The follow-up infra PR (`TECHOPS-460-aurora-pg-private`) adds the bastion-SG ingress rule on the RDS side and flips `publicly_accessible=false`.

## Test plan

- [x] Manually trigger `aws-weekly.yml` with `databases=[\"postgresql:aurora\"]` against this branch and confirm: `Open SSM tunnel to Aurora PG` runs and exports `TUNNELED_DB_PORT=15432`, the liquibase update succeeds against `localhost:15432`, and the maven test step passes.
- [ ] First scheduled `aws-weekly.yml` run after merge is green across the full matrix (postgresql:aurora through the tunnel, all other entries unchanged).
- [ ] No regression in mysql:aws (which now also runs through a tunnel via #1288) or any other DB.

## Out of scope

* Other postgres versions (`postgresql:12/13/14`): can adopt the same pattern in future PRs once their respective RDS modules flip private.
* `aws.yml` (daily): out of scope per the original TECHOPS-460 rollout plan.
* The matching `liquibase-infrastructure` PR that flips `aws-aurora-postgres` to `publicly_accessible=false` is filed separately under branch `TECHOPS-460-aurora-pg-private`.

Refs: TECHOPS-460, #1288, liquibase/liquibase-infrastructure#3715, liquibase/build-logic#595