### PR TITLE
[TECHOPS-506] Bump python-version to 3.12 in aws.yml to fix LocalStack startup

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.11.5'
+          python-version: '3.12'
     
       - name: Install liquibase and lpm
         run: |


### PR DESCRIPTION
## Summary

- Bumps `python-version` from `'3.11.5'` to `'3.12'` in `.github/workflows/aws.yml` (the only place this repo pins a Python version).
- Unblocks the AWS Cloud DB Test Execution workflow, which has been failing on **every job** in both the scheduled and manual runs since `localstack 2026.5.0` was released.

## Root cause

`localstack 2026.5.0` ships [PEP 701](https://peps.python.org/pep-0701/) f-string syntax (nested double-quotes inside an f-string) that's only valid on Python 3.12+, but its PyPI metadata still declares `requires_python>=3.10`. So pip happily installs it on the workflow's pinned Python 3.11.5, then the CLI crashes on first import:

```
File ".../site-packages/localstack_cli/cli/localstack.py", line 124
    A=status;...f"[bold]{A["runtime_version"]}[/bold]"...
                ^^^^^^^^^^^^^^^
SyntaxError: f-string: unmatched '['
```

Result: `localstack start -d` never runs and every job aborts at `Start & Configure LocalStack`. Full investigation in the ticket.

## Evidence

Failing runs (both 11/11 jobs failed at the same step):
- Scheduled: https://github.com/liquibase/liquibase-test-harness/actions/runs/26211528318
- Manual re-run: https://github.com/liquibase/liquibase-test-harness/actions/runs/26237016264

Jira: https://datical.atlassian.net/browse/TECHOPS-506 (epic: https://datical.atlassian.net/browse/TECHOPS-453)

## Test plan

- [ ] CI on this PR runs the AWS workflow with Python 3.12 and the `Start & Configure LocalStack` step completes successfully.
- [ ] At least one DB job (e.g. `test (postgresql:14)`) progresses past LocalStack startup into `Configure Test` / `Init * Database` / `AWS RDS - Test Run`.
- [ ] No regressions in the other steps that depend on Python (`localstack auth set-token`, `localstack wait`, secrets fetch via `awscli-local`).

## Follow-ups (not in this PR)

- The same Python pin likely lives in [`liquibase/build-logic`](https://github.com/liquibase/build-logic) for the azure/gcp/aws-weekly workflows; if those install `localstack` via pip on Python 3.11, they'll need the same bump there.
- File an upstream issue with LocalStack to correct `requires_python` to `>=3.12` in their packaging metadata.
- Transient `lpm` checksum failure observed in one `test (mysql:aurora)` run is unrelated and should be a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)