### PR TITLE
[TECHOPS-507] Route postgresql:12/13/14 through SSM tunnel

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -258,6 +258,62 @@ jobs:
             TH_PGRESURL_12, /testautomation/db_details/aws_postgresql_12_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
             TH_PGRESURL_13, /testautomation/db_details/aws_postgresql_13_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
             TH_PGRESURL_14, /testautomation/db_details/aws_postgresql_14_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+            SSM_BASTION_INSTANCE_ID, /testautomation/ssm/bastion_instance_id
+
+      # TECHOPS-507 (child of TECHOPS-460): route postgresql:12/13/14 init+test
+      # through the SSM port-forwarding tunnel so the underlying aws-postgres
+      # RDS instances can flip publicly_accessible=false. parse-postgres extracts
+      # host/port from the per-version JDBC URL; the composite action opens the
+      # tunnel and exports TUNNELED_DB_HOST/TUNNELED_DB_PORT for the liquibase +
+      # mvn steps below.
+      - name: Parse postgres endpoint from JDBC URL
+        id: parse-postgres
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion != 'aurora' }}
+        env:
+          JDBC_URL: ${{ env[format('TH_PGRESURL_{0}', steps.setup.outputs.databaseVersion)] }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # JDBC URL shape: jdbc:postgresql://<host>[:<port>]/<dbname>[?...]
+          tail="${JDBC_URL#jdbc:postgresql://}"
+          host_port="${tail%%/*}"
+          dbname_qs="${tail#*/}"
+          if [[ "$host_port" == *:* ]]; then
+            host="${host_port%%:*}"
+            port="${host_port##*:}"
+          else
+            host="$host_port"
+            port="5432"
+          fi
+          if [[ ! "$host" =~ ^[A-Za-z0-9.-]+$ ]] || [[ ! "$port" =~ ^[0-9]{1,5}$ ]]; then
+            echo "::error::Could not parse host/port from JDBC URL" >&2
+            exit 1
+          fi
+          echo "host=$host"           >> "$GITHUB_OUTPUT"
+          echo "port=$port"           >> "$GITHUB_OUTPUT"
+          echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Open SSM tunnel to postgres
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion != 'aurora' }}
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@main
+        with:
+          bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
+          db-host: ${{ steps.parse-postgres.outputs.host }}
+          db-port: ${{ steps.parse-postgres.outputs.port }}
+          local-port: '15432'
+
+      # liquibase/liquibase:latest (used by liquibase-github-action) does not
+      # bundle the PostgreSQL JDBC driver since 5.0.3. Stage it into
+      # liquibase_libs/ so the docker container picks it up via classpath.
+      - name: Install PostgreSQL JDBC driver
+        if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion != 'aurora' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p liquibase_libs
+          curl -fsSL -o liquibase_libs/postgresql.jar \
+            https://jdbc.postgresql.org/download/postgresql-42.7.4.jar
+          ls -la liquibase_libs/
 
       - name: Get AWS secrets
         if: ${{ steps.setup.outputs.databasePlatform == 'mariadb' }}
@@ -348,17 +404,30 @@ jobs:
           password: "${{env.TH_DB_PASSWD}}"
           url: "${{ env.TH_ORACLEURL_19_TH }}"
 
-      - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
+      # TECHOPS-507: cannot use liquibase/liquibase-github-action here because
+      # it spawns its own container with default bridge networking, so the SSM
+      # tunnel on the runner host's 127.0.0.1:15432 is unreachable. Run the
+      # liquibase image directly with --network host so the container shares
+      # the runner's loopback. Same pattern as the aurora-pg pilot (#1289).
+      - name: Init postgres via SSM tunnel
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion != 'aurora' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-        with:
-          operation: "update"
-          classpath: "src/test/resources/init-changelogs/aws"
-          changeLogFile: "postgresql.sql"
-          username: "${{env.TH_DB_ADMIN}}"
-          password: "${{env.TH_DB_PASSWD}}"
-          url: "${{ env[format('TH_PGRESURL_{0}', steps.setup.outputs.databaseVersion)] }}"
+          DB_USERNAME: ${{ env.TH_DB_ADMIN }}
+          DB_PASSWORD: ${{ env.TH_DB_PASSWD }}
+          POSTGRES_JDBC_URL: jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-postgres.outputs.dbname-qs }}
+        run: |
+          docker run --rm --network host \
+            -v "${PWD}:/workspace" \
+            -w /workspace \
+            -e LIQUIBASE_PRO_LICENSE_KEY \
+            liquibase/liquibase:latest \
+            --classpath="src/test/resources/init-changelogs/aws:liquibase_libs/postgresql.jar" \
+            --changeLogFile="postgresql.sql" \
+            --username="$DB_USERNAME" \
+            --password="$DB_PASSWORD" \
+            --url="$POSTGRES_JDBC_URL" \
+            update
 
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
         if: ${{ steps.setup.outputs.databasePlatform == 'mariadb' }}
@@ -443,12 +512,18 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion != 'aurora' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          TEST_CLASSES: ${{ needs.setup.outputs.testClasses }}
+          DB_PLATFORM: ${{ steps.setup.outputs.databasePlatform }}
+          DB_VERSION: ${{ steps.setup.outputs.databaseVersion }}
+          DB_USERNAME: ${{ env.TH_DB_ADMIN }}
+          DB_PASSWORD: ${{ env.TH_DB_PASSWD }}
+          POSTGRES_JDBC_URL: jdbc:postgresql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-postgres.outputs.dbname-qs }}
         run: |
           echo "::group::Dependency Tree (PRO - liquibase-commercial)"
           mvn -B -PuseProArtifacts -DuseProArtifacts=true dependency:tree 2>&1 | grep -E "(liquibase|BUILD SUCCESS)" || true
           echo "::endgroup::"
 
-          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=${{ steps.setup.outputs.databaseVersion }} -Dprefix=aws -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='${{ env[format('TH_PGRESURL_{0}', steps.setup.outputs.databaseVersion)] }}' test
+          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest="$TEST_CLASSES" -DconfigFile=/harness-config-cloud.yml -DdbName="$DB_PLATFORM" -DdbVersion="$DB_VERSION" -Dprefix=aws -DdbUsername="$DB_USERNAME" -DdbPassword="$DB_PASSWORD" -DdbUrl="$POSTGRES_JDBC_URL" test
 
       - name: AWS RDS ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Run
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}


### PR DESCRIPTION
## Summary

Mirrors the aurora-pg pilot (#1289) for the `aws-postgres` engine. After the aurora-pg private-flip landed and was verified end-to-end on 2026-05-21, GuardDuty fired on the next public RDS target in the same account: `postgresql-16-25923918622` (the v16 instance of the `aws-postgres` ephemeral module). The remediation is the same as aurora-pg: route CI through the SSM tunnel, then flip the cluster private.

This PR covers the test-harness half (the tunnel route). The infrastructure half is liquibase/liquibase-infrastructure on branch `TECHOPS-507-aws-postgres-private`; it merges *after* this one validates.

Scope: only the `postgresql && databaseVersion != 'aurora'` path in the `test` job. Aurora-pg already tunneled (#1289), and other matrix entries (mysql, mariadb, mssql, oracle, aurora-mysql) are untouched.

## What changes

`test` job, postgres non-aurora condition:

1. `Get AWS secrets` also fetches `/testautomation/ssm/bastion_instance_id` into `SSM_BASTION_INSTANCE_ID`.
2. **`Parse postgres endpoint from JDBC URL`** extracts host, port (defaulting to 5432 since the stored URL is hostname-only), and dbname from `env[format('TH_PGRESURL_{0}', steps.setup.outputs.databaseVersion)]`.
3. **`Open SSM tunnel to postgres`** uses `liquibase/build-logic/.github/actions/ssm-db-tunnel@main` and exports `TUNNELED_DB_HOST=localhost` / `TUNNELED_DB_PORT=15432`.
4. **`Install PostgreSQL JDBC driver`** downloads `postgresql-42.7.4.jar` into `liquibase_libs/` (Liquibase 5.0.3 in `liquibase/liquibase:latest` no longer bundles it; same fix as the aurora-pg pilot).
5. **`Init postgres via SSM tunnel`** replaces the previous `liquibase/liquibase-github-action` step with a direct `docker run --rm --network host liquibase/liquibase:latest ... update`. The action's container uses default bridge networking, so it cannot reach the host loopback where the tunnel listens; `--network host` shares the runner's netns.
6. Maven test step now uses `jdbc:postgresql://${TUNNELED_DB_HOST}:${TUNNELED_DB_PORT}/<dbname>`.

All secret-derived values (`TH_DB_ADMIN`, `TH_DB_PASSWD`, `JDBC_URL`, `testClasses`, `databasePlatform`, `databaseVersion`) are bound in the step `env:` block and referenced as shell vars in `run:`, per the CodeRabbit hardening applied on the aurora-pg PR.

## Why now

The aws-postgres module shares one SG and subnet group across all 4 versions it provisions (12, 13, 14, 16). Flipping the cluster private in the infra PR is atomic across versions, so all *tested* matrix entries (12, 13, 14) need to be routed through the tunnel before the infra PR merges or aws-weekly breaks.

## Dependencies

* Already merged: liquibase/liquibase-infrastructure#3715 (bastion + `/testautomation/ssm/bastion_instance_id`).
* Already merged: liquibase/build-logic#595 (`ssm-db-tunnel` composite action).
* Already merged: liquibase/liquibase-test-harness#1288 (mysql:aws pilot) and #1289 (aurora-pg pilot, which established the docker-network-host + JDBC-driver-staging patterns).
* Follows: liquibase/liquibase-infrastructure `TECHOPS-507-aws-postgres-private` (flip `aws-postgres` to `publicly_accessible=false`, merges after this one).

The bastion SG already permits egress to 5432 in the VPC CIDR, so this works against the still-public postgres cluster immediately. The follow-up infra PR adds the bastion-SG ingress rule on the postgres SG and removes `0.0.0.0/0`.

## Test plan

- [ ] Manually trigger `aws-weekly.yml` with `databases=[\"postgresql:12\"]` against this branch: tunnel step opens, liquibase init succeeds on `localhost:15432`, mvn test passes.
- [ ] Same for `databases=[\"postgresql:13\"]` and `databases=[\"postgresql:14\"]` (or one combined dispatch with all three).
- [ ] First scheduled `aws-weekly.yml` run after merge: postgres entries green via tunnel, no regression in aurora-pg / mysql / other matrix entries.

## Out of scope

* `postgresql:16` is not in the workflow matrix (only secrets for v12/13/14 are wired up), so it does not exercise the tunnel here. The infra PR still flips v16 private alongside the others since they share the SG/subnet group.
* `aws-mysql`, `aws-aurora-mysql`, `aws-oracle`, `aws-mssql`, `aws-mariadb` each get their own child ticket under TECHOPS-460.

Refs: [TECHOPS-507](https://datical.atlassian.net/browse/TECHOPS-507), parent [TECHOPS-460](https://datical.atlassian.net/browse/TECHOPS-460), liquibase/liquibase-infrastructure#3715, liquibase/build-logic#595, #1288, #1289.

[TECHOPS-507]: https://datical.atlassian.net/browse/TECHOPS-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ