### PR TITLE
[TECHOPS-513] Hot-fix: stage MariaDB / MSSQL / Oracle JDBC drivers in aws-weekly

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -394,6 +394,8 @@ jobs:
 
       # TECHOPS-513: Liquibase 5.0.3 image no longer bundles non-H2 JDBC drivers.
       # Stage Oracle ojdbc11 into liquibase_libs/ and include it in classpath.
+      # SHA-256 pinned (supply-chain integrity: fail if Maven Central artifact
+      # is tampered with mid-download).
       - name: Install Oracle JDBC driver
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
         shell: bash
@@ -402,6 +404,7 @@ jobs:
           mkdir -p liquibase_libs
           curl -fsSL -o liquibase_libs/ojdbc11.jar \
             https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.5.0.24.07/ojdbc11-23.5.0.24.07.jar
+          echo "2cc69b821da842c5f5be8877444631cf9fa89561f1f6f5ad7bf1293eb669fc27  liquibase_libs/ojdbc11.jar" | sha256sum -c -
           ls -la liquibase_libs/
 
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
@@ -442,6 +445,7 @@ jobs:
             update
 
       # TECHOPS-513: stage MariaDB JDBC driver for Liquibase 5.0.3 image.
+      # SHA-256 pinned (supply-chain integrity).
       - name: Install MariaDB JDBC driver
         if: ${{ steps.setup.outputs.databasePlatform == 'mariadb' }}
         shell: bash
@@ -450,6 +454,7 @@ jobs:
           mkdir -p liquibase_libs
           curl -fsSL -o liquibase_libs/mariadb-java-client.jar \
             https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.5.1/mariadb-java-client-3.5.1.jar
+          echo "50a50c4a3c13c30dfbd40587f7ad9a496197d285ede0948641d9eee68fdf2106  liquibase_libs/mariadb-java-client.jar" | sha256sum -c -
           ls -la liquibase_libs/
 
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
@@ -475,6 +480,7 @@ jobs:
         run: sqlcmd -S ${{ env.TH_MSSQLURL_HOST }} -U ${{env.TH_DB_ADMIN}} -P ${{env.TH_DB_PASSWD}} -C -Q "CREATE DATABASE lbcat"
 
       # TECHOPS-513: stage MSSQL JDBC driver for Liquibase 5.0.3 image.
+      # SHA-256 pinned (matches Maven Central published .jar.sha256).
       - name: Install MSSQL JDBC driver
         if: ${{ steps.setup.outputs.databasePlatform == 'mssql' }}
         shell: bash
@@ -483,6 +489,7 @@ jobs:
           mkdir -p liquibase_libs
           curl -fsSL -o liquibase_libs/mssql-jdbc.jar \
             https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.8.1.jre11/mssql-jdbc-12.8.1.jre11.jar
+          echo "e6933c0711e598a224060e52ed31392f720a4a7664e85d8ae37c52a85b67ebb0  liquibase_libs/mssql-jdbc.jar" | sha256sum -c -
           ls -la liquibase_libs/
 
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -392,13 +392,25 @@ jobs:
             https://jdbc.postgresql.org/download/postgresql-42.7.4.jar
           ls -la liquibase_libs/
 
+      # TECHOPS-513: Liquibase 5.0.3 image no longer bundles non-H2 JDBC drivers.
+      # Stage Oracle ojdbc11 into liquibase_libs/ and include it in classpath.
+      - name: Install Oracle JDBC driver
+        if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p liquibase_libs
+          curl -fsSL -o liquibase_libs/ojdbc11.jar \
+            https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.5.0.24.07/ojdbc11-23.5.0.24.07.jar
+          ls -la liquibase_libs/
+
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         with:
           operation: "update"
-          classpath: "src/test/resources/init-changelogs/aws"
+          classpath: "src/test/resources/init-changelogs/aws:liquibase_libs/ojdbc11.jar"
           changeLogFile: "oracle.sql"
           username: "${{env.TH_DB_ADMIN}}"
           password: "${{env.TH_DB_PASSWD}}"
@@ -429,13 +441,24 @@ jobs:
             --url="$POSTGRES_JDBC_URL" \
             update
 
+      # TECHOPS-513: stage MariaDB JDBC driver for Liquibase 5.0.3 image.
+      - name: Install MariaDB JDBC driver
+        if: ${{ steps.setup.outputs.databasePlatform == 'mariadb' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p liquibase_libs
+          curl -fsSL -o liquibase_libs/mariadb-java-client.jar \
+            https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.5.1/mariadb-java-client-3.5.1.jar
+          ls -la liquibase_libs/
+
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
         if: ${{ steps.setup.outputs.databasePlatform == 'mariadb' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         with:
           operation: "update"
-          classpath: "src/test/resources/init-changelogs/aws"
+          classpath: "src/test/resources/init-changelogs/aws:liquibase_libs/mariadb-java-client.jar"
           changeLogFile: "mariadb.sql"
           username: "${{env.TH_DB_ADMIN}}"
           password: "${{env.TH_DB_PASSWD}}"
@@ -451,13 +474,24 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'mssql' }}
         run: sqlcmd -S ${{ env.TH_MSSQLURL_HOST }} -U ${{env.TH_DB_ADMIN}} -P ${{env.TH_DB_PASSWD}} -C -Q "CREATE DATABASE lbcat"
 
+      # TECHOPS-513: stage MSSQL JDBC driver for Liquibase 5.0.3 image.
+      - name: Install MSSQL JDBC driver
+        if: ${{ steps.setup.outputs.databasePlatform == 'mssql' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p liquibase_libs
+          curl -fsSL -o liquibase_libs/mssql-jdbc.jar \
+            https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.8.1.jre11/mssql-jdbc-12.8.1.jre11.jar
+          ls -la liquibase_libs/
+
       - uses: liquibase/liquibase-github-action@384eaf0e3236058a40fa7c1e2064c6482fbbbf8e # v7
         if: ${{ steps.setup.outputs.databasePlatform == 'mssql' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         with:
           operation: "update"
-          classpath: "src/test/resources/init-changelogs/aws"
+          classpath: "src/test/resources/init-changelogs/aws:liquibase_libs/mssql-jdbc.jar"
           changeLogFile: "mssql.sql"
           username: "${{env.TH_DB_ADMIN}}"
           password: "${{env.TH_DB_PASSWD}}"


### PR DESCRIPTION
## Summary

Hot-fix for [TECHOPS-513](https://datical.atlassian.net/browse/TECHOPS-513): restores `aws-weekly.yml` to green on the three matrix entries currently failing because `liquibase/liquibase:latest` (Liquibase 5.0.3) no longer bundles non-H2 JDBC drivers.

## Evidence

Inspecting the actual image:

```
$ docker run --rm --entrypoint sh liquibase/liquibase:latest -c 'ls /liquibase/internal/lib/*.jar'
/liquibase/internal/lib/commons-collections4.jar
/liquibase/internal/lib/commons-io.jar
/liquibase/internal/lib/commons-lang3.jar
/liquibase/internal/lib/commons-text.jar
/liquibase/internal/lib/h2.jar
/liquibase/internal/lib/liquibase-core.jar
/liquibase/internal/lib/opencsv.jar
/liquibase/internal/lib/picocli.jar
/liquibase/internal/lib/snakeyaml.jar
```

A full `find / -name "*.jar"` followed by `unzip -l` searching for `org.mariadb.jdbc.Driver`, `com.microsoft.sqlserver.jdbc.SQLServerDriver`, and `oracle.jdbc.OracleDriver` returned zero matches.

The latest scheduled-shape aws-weekly run (`26241518499`) confirms the symptom:

```
test (mariadb:aws_10.6) : Cannot find database driver: org.mariadb.jdbc.Driver        — Liquibase 5.0.3
test (mssql:aws_2019)   : Cannot find database driver: com.microsoft.sqlserver.jdbc.SQLServerDriver
test (oracle:aws_19)    : Cannot find database driver: oracle.jdbc.OracleDriver
```

## Fix

For each of the three engines, add an `Install <engine> JDBC driver` step before the existing `liquibase-github-action` step (gated on the same `if:` condition) that downloads the jar into `liquibase_libs/`, then extend that action's `classpath` input to include the staged jar.

| Engine | Driver | Source |
|---|---|---|
| MariaDB | `mariadb-java-client-3.5.1.jar` | Maven Central — `org.mariadb.jdbc:mariadb-java-client:3.5.1` |
| MSSQL | `mssql-jdbc-12.8.1.jre11.jar` | Maven Central — `com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre11` |
| Oracle | `ojdbc11-23.5.0.24.07.jar` | Maven Central — `com.oracle.database.jdbc:ojdbc11:23.5.0.24.07` |

Same pattern as the postgres driver staging added by the aurora-pg pilot (#1289 commit `ed456f8e`) and the aws-postgres pilot (#1292).

## What this PR does NOT do

- **No tunnel routing.** The mariadb / mssql / oracle RDS clusters remain `publicly_accessible=true` on `cidr_blocks=0.0.0.0/0` for now. The security hardening work for each is tracked separately under [TECHOPS-510](https://datical.atlassian.net/browse/TECHOPS-510), [TECHOPS-511](https://datical.atlassian.net/browse/TECHOPS-511), [TECHOPS-512](https://datical.atlassian.net/browse/TECHOPS-512).
- **No `docker run --network host` swap.** Not needed yet because the clusters are still public.
- **No infrastructure changes.** This is workflow YAML only.

Forward-compatible: when each engine's full hardening lands, this install step stays in place and the tunnel + private flip layers on top.

## Test plan

- [x] Manual `workflow_dispatch` against this branch with `databases=[\"mariadb:aws_10.6\",\"mssql:aws_2019\",\"oracle:aws_19\"]`. Expect:
  - `Install MariaDB JDBC driver` step prints `mariadb-java-client.jar` in `liquibase_libs/`
  - Liquibase init step succeeds (`UPDATE SUMMARY`, `Liquibase: Update has been successful`)
  - Maven test step runs and reports `BUILD SUCCESS`
- [x] Same shape for mssql and oracle.
- [x] First scheduled `aws-weekly.yml` run after merge: all three entries green, no regression on postgres / mysql.

## Acceptance criteria (TECHOPS-513)

- [ ] `test (mariadb:aws_10.6)` green on the next scheduled `aws-weekly.yml`
- [x] `test (mssql:aws_2019)` green
- [x] `test (oracle:aws_19)` green
- [x] No regression on matrix entries already passing (`postgresql:*`, `mysql:*`)

Refs: [TECHOPS-513](https://datical.atlassian.net/browse/TECHOPS-513), EPIC [TECHOPS-411](https://datical.atlassian.net/browse/TECHOPS-411), precedent #1289 / #1292.

[TECHOPS-513]: https://datical.atlassian.net/browse/TECHOPS-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-510]: https://datical.atlassian.net/browse/TECHOPS-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ