### PR TITLE
[TECHOPS-508] Route mysql:aws test job through SSM tunnel

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -235,6 +235,47 @@ jobs:
         with:
           secret-ids: |
             TH_MYSQLURL_8_0, /testautomation/db_details/aws_mysql_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+            SSM_BASTION_INSTANCE_ID, /testautomation/ssm/bastion_instance_id
+
+      # TECHOPS-508 (child of TECHOPS-460): route the mysql:aws mvn test step
+      # through the SSM port-forwarding tunnel so the aws-mysql RDS instance
+      # can flip publicly_accessible=false. The init step in the init-mysql
+      # container job is already tunneled via #1288.
+      - name: Parse mysql endpoint from JDBC URL
+        id: parse-mysql-test
+        if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aws' }}
+        env:
+          JDBC_URL: ${{ env.TH_MYSQLURL_8_0 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # JDBC URL shape: jdbc:mysql://<host>:<port>/<dbname>[?...]
+          tail="${JDBC_URL#jdbc:mysql://}"
+          host_port="${tail%%/*}"
+          dbname_qs="${tail#*/}"
+          if [[ "$host_port" == *:* ]]; then
+            host="${host_port%%:*}"
+            port="${host_port##*:}"
+          else
+            host="$host_port"
+            port="3306"
+          fi
+          if [[ ! "$host" =~ ^[A-Za-z0-9.-]+$ ]] || [[ ! "$port" =~ ^[0-9]{1,5}$ ]]; then
+            echo "::error::Could not parse host/port from JDBC URL" >&2
+            exit 1
+          fi
+          echo "host=$host"           >> "$GITHUB_OUTPUT"
+          echo "port=$port"           >> "$GITHUB_OUTPUT"
+          echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Open SSM tunnel to mysql
+        if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aws' }}
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@main
+        with:
+          bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
+          db-host: ${{ steps.parse-mysql-test.outputs.host }}
+          db-port: ${{ steps.parse-mysql-test.outputs.port }}
+          local-port: '13306'
 
       - name: Get AWS secrets
         if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aurora' }}
@@ -592,12 +633,18 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aws' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          TEST_CLASSES: ${{ needs.setup.outputs.testClasses }}
+          DB_PLATFORM: ${{ steps.setup.outputs.databasePlatform }}
+          DB_VERSION: ${{ steps.setup.outputs.databaseVersion }}
+          DB_USERNAME: ${{ env.TH_DB_ADMIN }}
+          DB_PASSWORD: ${{ env.TH_DB_PASSWD }}
+          MYSQL_JDBC_URL: jdbc:mysql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-mysql-test.outputs.dbname-qs }}
         run: |
           echo "::group::Dependency Tree (PRO - liquibase-commercial)"
           mvn -B -PuseProArtifacts -DuseProArtifacts=true dependency:tree 2>&1 | grep -E "(liquibase|BUILD SUCCESS)" || true
           echo "::endgroup::"
 
-          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=${{ steps.setup.outputs.databaseVersion }} -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='${{ env.TH_MYSQLURL_8_0 }}' test
+          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest="$TEST_CLASSES" -DconfigFile=/harness-config-cloud.yml -DdbName="$DB_PLATFORM" -DdbVersion="$DB_VERSION" -DdbUsername="$DB_USERNAME" -DdbPassword="$DB_PASSWORD" -DdbUrl="$MYSQL_JDBC_URL" test
 
       - name: AWS RDS ${{ steps.setup.outputs.databasePlatform }}-${{ steps.setup.outputs.databaseVersion }} Test Run
         if: ${{ steps.setup.outputs.databasePlatform == 'mssql' }}


### PR DESCRIPTION
## Summary

Mirrors the aurora-pg pilot (#1289) and the aws-postgres pilot (#1292) for `mysql:aws`. Continues the TECHOPS-460 follow-up sweep so the `aws-mysql` RDS instance can flip `publicly_accessible=false`.

Note: the init-mysql container job already tunnels `mysql:aws` via #1288. This PR tunnels what remains — the `test` job's mvn run, which currently uses the direct public `TH_MYSQLURL_8_0` URL.

## What changes

`test` job, `mysql:aws` matrix entry only:

1. **`Get AWS secrets`** also fetches `/testautomation/ssm/bastion_instance_id` into `SSM_BASTION_INSTANCE_ID`.
2. **`Parse mysql endpoint from JDBC URL`** extracts host, port (defaulting to 3306 if absent), and dbname from `TH_MYSQLURL_8_0`.
3. **`Open SSM tunnel to mysql`** uses `liquibase/build-logic/.github/actions/ssm-db-tunnel@main`, local-port `13306` (same as init-mysql pilot).
4. **mvn test step** uses `jdbc:mysql://${TUNNELED_DB_HOST}:${TUNNELED_DB_PORT}/<dbname>`. All secret-derived values bound in `env:` block and referenced as shell vars per the CodeRabbit hardening applied on the aurora-pg pilot.

No `docker run --network host` workaround needed because mysql:aws does not use `liquibase-github-action` in the test job (init lives in the container `init-mysql` job).

## Dependencies

* Already merged: liquibase/liquibase-infrastructure#3715 (bastion + `/testautomation/ssm/bastion_instance_id`).
* Already merged: liquibase/build-logic#595 (`ssm-db-tunnel` composite action).
* Already merged: liquibase/liquibase-test-harness#1288 (mysql:aws init tunnel), #1289 (aurora-pg pilot), #1292 (aws-postgres pilot).
* Follows: liquibase/liquibase-infrastructure `TECHOPS-508-aws-mysql-private` (flip `aws-mysql` to `publicly_accessible=false`, merges after this one).

The bastion SG already permits egress to 3306 in the VPC CIDR, so this works against the still-public mysql cluster immediately. The follow-up infra PR adds the bastion-SG ingress on the mysql SG and removes `0.0.0.0/0`.

## Test plan

- [ ] Manually trigger `aws-weekly.yml` with `databases=[\"mysql:aws\"]` against this branch: tunnel step opens, mvn test step uses `localhost:13306`, BUILD SUCCESS.
- [ ] First scheduled `aws-weekly.yml` run after merge: mysql:aws green via tunnel; no regression on aurora-pg, aws-postgres, mysql:aurora, or other matrix entries.

## Out of scope

* mysql:aurora: tracked under [TECHOPS-509](https://datical.atlassian.net/browse/TECHOPS-509).
* Remaining engines (mariadb, mssql, oracle): TECHOPS-511 / 510 / 512.

Refs: [TECHOPS-508](https://datical.atlassian.net/browse/TECHOPS-508), parent [TECHOPS-460](https://datical.atlassian.net/browse/TECHOPS-460), EPIC [TECHOPS-411](https://datical.atlassian.net/browse/TECHOPS-411), #1288, #1289, #1292.

[TECHOPS-509]: https://datical.atlassian.net/browse/TECHOPS-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ