### PR TITLE
[TECHOPS-509] Route mysql:aurora test job through SSM tunnel

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           secret-ids: |
             TH_AURORA_MYSQLURL, /testautomation/db_details/aurora_mysql_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+            SSM_BASTION_INSTANCE_ID, /testautomation/ssm/bastion_instance_id
       #This additional init step is required because of mysql driver issue on GH actions
       - name: Install Dependencies
         run: lpm update && lpm add mysql
@@ -145,7 +146,7 @@ jobs:
           echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
 
       - name: Install AWS CLI and netcat
-        if: ${{ matrix.version == 'aws' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aws'))) }}
+        if: ${{ matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (contains(needs.setup.outputs.databases, 'mysql:aws') || contains(needs.setup.outputs.databases, 'mysql:aurora')))) }}
         shell: bash
         run: |
           set -euo pipefail
@@ -176,11 +177,50 @@ jobs:
           TUNNELED_MYSQL_URL: jdbc:mysql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-mysql.outputs.dbname-qs }}
         run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}_cloud.sql" --username="${{ env.TH_DB_ADMIN }}" --password="${{ env.TH_DB_PASSWD }}" --url="${{ env.TUNNELED_MYSQL_URL }}" update
 
+      # TECHOPS-509: mirror the mysql:aws tunneling pattern for mysql:aurora so
+      # init-mysql still works once aws-aurora-mysql flips publicly_accessible=false.
+      - name: Parse Aurora MySQL endpoint from JDBC URL
+        id: parse-aurora-mysql-init
+        if: ${{ matrix.version == 'aurora' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
+        env:
+          JDBC_URL: ${{ env.TH_AURORA_MYSQLURL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # JDBC URL shape: jdbc:mysql://<host>[:<port>]/<dbname>[?...]
+          tail="${JDBC_URL#jdbc:mysql://}"
+          host_port="${tail%%/*}"
+          dbname_qs="${tail#*/}"
+          if [[ "$host_port" == *:* ]]; then
+            host="${host_port%%:*}"
+            port="${host_port##*:}"
+          else
+            host="$host_port"
+            port="3306"
+          fi
+          if [[ ! "$host" =~ ^[A-Za-z0-9.-]+$ ]] || [[ ! "$port" =~ ^[0-9]{1,5}$ ]]; then
+            echo "::error::Could not parse host/port from JDBC URL" >&2
+            exit 1
+          fi
+          echo "host=$host"           >> "$GITHUB_OUTPUT"
+          echo "port=$port"           >> "$GITHUB_OUTPUT"
+          echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Open SSM tunnel to Aurora MySQL
+        if: ${{ matrix.version == 'aurora' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@main
+        with:
+          bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
+          db-host: ${{ steps.parse-aurora-mysql-init.outputs.host }}
+          db-port: ${{ steps.parse-aurora-mysql-init.outputs.port }}
+          local-port: '13306'
+
       - name: Init Database
         if: ${{ matrix.version == 'aurora' && matrix.database == 'mysql' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(needs.setup.outputs.databases, 'mysql:aurora'))) }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
-        run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}_cloud.sql" --username="${{ env.TH_DB_ADMIN }}" --password="${{ env.TH_DB_PASSWD }}" --url="${{ env.TH_AURORA_MYSQLURL }}" update
+          TUNNELED_AURORA_MYSQL_URL: jdbc:mysql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-mysql-init.outputs.dbname-qs }}
+        run: liquibase --classpath="src/test/resources/init-changelogs/aws" --changeLogFile="${{ matrix.database }}_cloud.sql" --username="${{ env.TH_DB_ADMIN }}" --password="${{ env.TH_DB_PASSWD }}" --url="${{ env.TUNNELED_AURORA_MYSQL_URL }}" update
 
   test:
     needs: [deploy-ephemeral-cloud-infra, init-mysql, setup]

--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -283,6 +283,47 @@ jobs:
         with:
           secret-ids: |
             TH_AURORA_MYSQLURL, /testautomation/db_details/aurora_mysql_jdbc_${{ needs.deploy-ephemeral-cloud-infra.outputs.resources_id }}
+            SSM_BASTION_INSTANCE_ID, /testautomation/ssm/bastion_instance_id
+
+      # TECHOPS-509 (child of TECHOPS-460): route the mysql:aurora mvn test
+      # step through the SSM port-forwarding tunnel so the aws-aurora-mysql
+      # cluster can flip publicly_accessible=false. init-mysql container job
+      # already tunnels mysql:aurora via #1288.
+      - name: Parse aurora-mysql endpoint from JDBC URL
+        id: parse-aurora-mysql
+        if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aurora' }}
+        env:
+          JDBC_URL: ${{ env.TH_AURORA_MYSQLURL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # JDBC URL shape: jdbc:mysql://<host>[:<port>]/<dbname>[?...]
+          tail="${JDBC_URL#jdbc:mysql://}"
+          host_port="${tail%%/*}"
+          dbname_qs="${tail#*/}"
+          if [[ "$host_port" == *:* ]]; then
+            host="${host_port%%:*}"
+            port="${host_port##*:}"
+          else
+            host="$host_port"
+            port="3306"
+          fi
+          if [[ ! "$host" =~ ^[A-Za-z0-9.-]+$ ]] || [[ ! "$port" =~ ^[0-9]{1,5}$ ]]; then
+            echo "::error::Could not parse host/port from JDBC URL" >&2
+            exit 1
+          fi
+          echo "host=$host"           >> "$GITHUB_OUTPUT"
+          echo "port=$port"           >> "$GITHUB_OUTPUT"
+          echo "dbname-qs=$dbname_qs" >> "$GITHUB_OUTPUT"
+
+      - name: Open SSM tunnel to aurora-mysql
+        if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aurora' }}
+        uses: liquibase/build-logic/.github/actions/ssm-db-tunnel@main
+        with:
+          bastion-instance-id: ${{ env.SSM_BASTION_INSTANCE_ID }}
+          db-host: ${{ steps.parse-aurora-mysql.outputs.host }}
+          db-port: ${{ steps.parse-aurora-mysql.outputs.port }}
+          local-port: '13306'
 
       - name: Get AWS secrets
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
@@ -661,12 +702,18 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'mysql' && steps.setup.outputs.databaseVersion == 'aurora' }}
         env:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          TEST_CLASSES: ${{ needs.setup.outputs.testClasses }}
+          DB_PLATFORM: ${{ steps.setup.outputs.databasePlatform }}
+          DB_VERSION: ${{ steps.setup.outputs.databaseVersion }}
+          DB_USERNAME: ${{ env.TH_DB_ADMIN }}
+          DB_PASSWORD: ${{ env.TH_DB_PASSWD }}
+          AURORA_MYSQL_JDBC_URL: jdbc:mysql://${{ env.TUNNELED_DB_HOST }}:${{ env.TUNNELED_DB_PORT }}/${{ steps.parse-aurora-mysql.outputs.dbname-qs }}
         run: |
           echo "::group::Dependency Tree (PRO - liquibase-commercial)"
           mvn -B -PuseProArtifacts -DuseProArtifacts=true dependency:tree 2>&1 | grep -E "(liquibase|BUILD SUCCESS)" || true
           echo "::endgroup::"
 
-          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest=${{ needs.setup.outputs.testClasses }} -DconfigFile=/harness-config-cloud.yml -DdbName=${{ steps.setup.outputs.databasePlatform }} -DdbVersion=${{ steps.setup.outputs.databaseVersion }} -DdbUsername=${{env.TH_DB_ADMIN}} -DdbPassword=${{env.TH_DB_PASSWD}} -DdbUrl='${{ env.TH_AURORA_MYSQLURL }}' test
+          mvn -PuseProArtifacts -DuseProArtifacts=true -Dtest="$TEST_CLASSES" -DconfigFile=/harness-config-cloud.yml -DdbName="$DB_PLATFORM" -DdbVersion="$DB_VERSION" -DdbUsername="$DB_USERNAME" -DdbPassword="$DB_PASSWORD" -DdbUrl="$AURORA_MYSQL_JDBC_URL" test
 
       - name: AWS Aurora ${{ steps.setup.outputs.databasePlatform }} Test Run
         if: ${{ steps.setup.outputs.databasePlatform == 'postgresql' && steps.setup.outputs.databaseVersion == 'aurora' }}


### PR DESCRIPTION
## Summary

Sister of [TECHOPS-508](https://datical.atlassian.net/browse/TECHOPS-508). Mirrors the aurora-pg pilot (#1289), aws-postgres (#1292), and mysql:aws (#1296) for `mysql:aurora`. Continues the TECHOPS-460 follow-up sweep so the `aws-aurora-mysql` cluster can flip `publicly_accessible=false`.

The init-mysql container job already tunnels `mysql:aurora` via #1288. This PR tunnels what remains — the `test` job's mvn run, which currently uses the direct public `TH_AURORA_MYSQLURL`.

## What changes

`test` job, `mysql && databaseVersion == 'aurora'` path only:

1. `Get AWS secrets` also fetches `/testautomation/ssm/bastion_instance_id` into `SSM_BASTION_INSTANCE_ID`.
2. New `Parse aurora-mysql endpoint from JDBC URL` step extracts host/port/dbname from `TH_AURORA_MYSQLURL`.
3. New `Open SSM tunnel to aurora-mysql` step uses `ssm-db-tunnel@main`, local-port `13306`.
4. `AWS Aurora ${dbplatform} Test Run` mvn step uses `jdbc:mysql://${TUNNELED_DB_HOST}:${TUNNELED_DB_PORT}/<dbname>`. Secrets bound to step `env:` block per CodeRabbit hardening.

## Dependencies + merge order

* Already merged: #3715 (bastion), build-logic#595 (composite action), #1288 (mysql init tunnel), #1289 (aurora-pg), #1292 (aws-postgres), #1296 (mysql:aws).
* Follows: `liquibase-infrastructure` branch `TECHOPS-509-aws-aurora-mysql-private` (flip `aws-aurora-mysql` private), merges after this one.

## Test plan

- [ ] Manually trigger \`aws-weekly.yml\` with \`databases=[\"mysql:aurora\"]\` against this branch; expect tunnel step opens and mvn test passes against tunneled URL.
- [ ] First scheduled \`aws-weekly.yml\` run after merge: mysql:aurora green via tunnel.

Refs: [TECHOPS-509](https://datical.atlassian.net/browse/TECHOPS-509), parent [TECHOPS-460](https://datical.atlassian.net/browse/TECHOPS-460), EPIC [TECHOPS-411](https://datical.atlassian.net/browse/TECHOPS-411), #1288, #1289, #1292, #1296.

[TECHOPS-508]: https://datical.atlassian.net/browse/TECHOPS-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-509]: https://datical.atlassian.net/browse/TECHOPS-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ