### PR TITLE
Re-enable Slack failure notifications

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -43,17 +43,11 @@ jobs:
     # workflow_run.conclusion is one of: success, failure, cancelled,
     # timed_out, action_required, neutral, skipped, stale. Manual dispatch
     # always runs (it is the test path).
-    #
-    # TEMPORARILY DISABLED: the `false &&` short-circuits all notifications
-    # while we work through the TECHOPS-460 audit sweep (mariadb/mssql/oracle
-    # PRs are intentionally producing failure noise during dev). Remove the
-    # `false &&` to re-enable.
     if: >-
-      false &&
-      (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'failure' ||
       github.event.workflow_run.conclusion == 'timed_out' ||
-      github.event.workflow_run.conclusion == 'cancelled')
+      github.event.workflow_run.conclusion == 'cancelled'
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials for vault access


### PR DESCRIPTION
## Summary

Removes the `false &&` short-circuit on the `notify` job in `.github/workflows/notify-slack-on-failure.yml` and the "TEMPORARILY DISABLED" comment block above it, so the central failure notifier resumes posting to Slack for failed / timed_out / cancelled upstream runs.

## Why this was disabled

During the TECHOPS-460 audit sweep (mariadb / mssql / oracle tunnel work) the test-harness CI was intentionally producing expected failures while we iterated on smoke runs. The `false &&` short-circuit was a temporary measure to keep real-incident signal-to-noise high in the alerts channel.

## Why it is safe to re-enable now

The sweep is done:

* mssql tunnel work validated end-to-end on smoke run [26293743526](https://github.com/liquibase/liquibase-test-harness/actions/runs/26293743526).
* Full 3-engine smoke run [26295883972](https://github.com/liquibase/liquibase-test-harness/actions/runs/26295883972): oracle ✅, mssql ✅, mariadb tunnel steps ✅ (mariadb mvn-test surfaces 3 pre-existing snapshot-drift failures unrelated to infra: `createFunction` / `createPackage` / `createPackageBody` on MariaDB 10.6).
* `harden-mariadb-mssql-oracle-tunnel` (#1298) is ready to land. Any future failures from here will be real and should page the team.

## Test plan

- [ ] Manually dispatch `notify-slack-on-failure.yml` against a known-failed run id (e.g. `26295883972`) and confirm a Slack post lands in the alerts channel.
- [ ] First real failed upstream run after this merges: confirm Slack notification fires.