### PR TITLE
chore: set version to 1.0.12-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.liquibase</groupId>
   <artifactId>liquibase-test-harness</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.12-SNAPSHOT</version>
   <name>Liquibase Test Harness</name>
   <description>Test Harness For Liquibase</description>
   <url>https://github.com/liquibase/liquibase-test-harness</url>


### PR DESCRIPTION
## What

Sets the project artifact version to `1.0.12-SNAPSHOT` (from `1.1.0-SNAPSHOT`) for the 1.0.12 release line.

## Why

Aligns the test harness version with the intended 1.0.12 release.

## Changes

- `pom.xml`: `<version>` `1.1.0-SNAPSHOT` → `1.0.12-SNAPSHOT`

## Notes

Version-only change. No code or test data is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)