### PR TITLE
[INT-1901] Fix startup_failure in Attach Artifact to Release workflow

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -5,9 +5,13 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+  actions: read
+  packages: write
+  id-token: write
+
 jobs:
   attach-artifact-to-release:
     uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
     secrets: inherit
-    permissions:
-      contents: read  


### PR DESCRIPTION
## Problem

The **Attach Artifact to Release** workflow fails at startup (`startup_failure`) — the run dies during setup, before any job executes. Example: [run 26519048563](https://github.com/liquibase/liquibase-test-harness/actions/runs/26519048563).

## Root cause

`attach-artifact-release.yml` calls the reusable workflow `liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main`, which requires:

```yaml
permissions:
  contents: write
  actions: read
  packages: write
  id-token: write   # OIDC, via aws-actions/configure-aws-credentials (used in 3 jobs)
```

The caller only granted **job-level** `contents: read`. The `id-token: write` permission can **only be granted by the caller** — a reusable workflow cannot grant itself OIDC permission. With the caller allowing `id-token: none`, GitHub refuses to start the run.

This also explains why the failure surfaced on an *open* PR despite the `types: [closed]` trigger: a workflow-validation failure short-circuits into a `startup_failure` run before the event-type filter is applied. The restrictive permissions were introduced in `c5ab4cbf` and only became fatal once the reusable workflow started requiring `id-token`/`packages`/`contents: write`.

## Fix

Move `permissions` to the workflow top level and grant the full set the reusable workflow needs — matching the working sibling extensions (`liquibase-databricks`, `liquibase-commercial-snowflake`), which use the identical reusable workflow.

```yaml
permissions:
  contents: write
  actions: read
  packages: write
  id-token: write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)