### PR TITLE
Make CockroachDB test be able to run on secure clusters

### DIFF
--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -346,7 +346,7 @@ services:
     volumes:
       - ./setup_db.sh:/setup_db.sh
     entrypoint: "/bin/bash"
-    command: /setup_db.sh crdb-23.1
+    command: /setup_db.sh crdb-23.1 --insecure
     depends_on:
       - crdb-23.1
 
@@ -369,7 +369,7 @@ services:
     volumes:
       - ./setup_db.sh:/setup_db.sh
     entrypoint: "/bin/bash"
-    command: /setup_db.sh crdb-23.2
+    command: /setup_db.sh crdb-23.2 --insecure
     depends_on:
       - crdb-23.2
 
@@ -392,7 +392,7 @@ services:
     volumes:
       - ./setup_db.sh:/setup_db.sh
     entrypoint: "/bin/bash"
-    command: /setup_db.sh crdb-24.1
+    command: /setup_db.sh crdb-24.1 --insecure
     depends_on:
       - crdb-24.1
 

--- a/src/test/resources/docker/setup_db.sh
+++ b/src/test/resources/docker/setup_db.sh
@@ -3,8 +3,9 @@
 #sleep 10
 
 HOST=$1
-HOSTPARAMS="--host $HOST --insecure"
-SQL="/cockroach/cockroach.sh sql $HOSTPARAMS"
+ARGS=$2
+HOSTPARAMS="--host $HOST"
+SQL="/cockroach/cockroach.sh sql $HOSTPARAMS $ARGS"
 
 $SQL -e "CREATE DATABASE lbcat;"
 $SQL -e "CREATE USER lbuser;"


### PR DESCRIPTION
## Summary

Takes over #724 by @DarrylWong (with his blessing — see [this comment](https://github.com/liquibase/liquibase-test-harness/pull/724#issuecomment-4626003994)), rebased onto current `main` and with the original CI failure fixed.

`setup_db.sh` previously hardcoded `--insecure`, so the harness CockroachDB setup could only run against insecure clusters. This change:

- `setup_db.sh` now takes connection args as a second parameter (`ARGS=$2`) instead of hardcoding `--insecure`
- `docker-compose.yml` passes `--insecure` explicitly to the three crdb init services (`crdb-23.1`, `crdb-23.2`, `crdb-24.1`), preserving existing CI behavior
- Secure clusters (e.g. CockroachDB's own test runs) can now pass `--certs-dir=...` instead

### Difference from #724

The original PR appended `--insecure` to the **volume mount** line (`- ./setup_db.sh:/setup_db.sh --insecure`), which is a no-op for arg passing — that's why CI failed with `ERROR: cannot establish secure connection to insecure server`. Here the flag is passed on the **command** line (`command: /setup_db.sh crdb-24.1 --insecure`) where it actually reaches the script.

## Verification (local)

- `crdb-24.1` + `crdb-24.1-init` via docker compose: init completes cleanly (`CREATE DATABASE` / `CREATE ROLE` / inserts all succeed) with `--insecure` passed as `$2`
- Running `setup_db.sh` **without** the arg attempts a TLS connection and is refused by the insecure server (`server refused TLS connection`) — confirming the flag is no longer hardcoded and secure mode is reachable
- `mvn test -Dtest=ChangeObjectTests -DdbName=cockroachdb -DdbVersion=24.1 -DchangeObjects=createTable` → `Tests run: 2, Failures: 0, Errors: 0`

Supersedes #724 and #732.

Co-authored-by: DarrylWong <darryl@cockroachlabs.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)