### PR TITLE
chore(deps): bump spock-reports to 2.6.0-groovy-5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <gmavenplus-plugin.version>5.0.0</gmavenplus-plugin.version>
     <groovy-all.version>5.0.6</groovy-all.version>
     <spock-core.version>2.4-groovy-5.0</spock-core.version>
-    <spock-reports.version>2.5.1-groovy-4.0</spock-reports.version>
+    <spock-reports.version>2.6.0-groovy-5.0</spock-reports.version>
     <junit.version>6.1.0</junit.version>
     <!-- DEPRECATED: Apache Derby entered read-only maintenance mode (2025-10-10). Driver requires Java 21 but project needs Java 17.
              Keeping commented for reference. See INT-1718 for details.
@@ -250,7 +250,7 @@
     <dependency>
       <groupId>com.athaydes</groupId>
       <artifactId>spock-reports</artifactId>
-      <version>2.5.1-groovy-4.0</version>
+      <version>${spock-reports.version}</version>
       <scope>test</scope>
       <!-- this avoids affecting your version of Groovy/Spock -->
       <exclusions>


### PR DESCRIPTION
## What

Bumps `spock-reports` from `2.5.1-groovy-4.0` → `2.6.0-groovy-5.0`.

## Why

- First release of `spock-reports` in ~3 years, and it now ships a **Groovy 5.0**-aligned artifact. The harness already runs on Groovy 5.0, so we were previously relying on the older `groovy-4.0` build happening to be compatible (it runs in a separate process, which is why we got away with it).
- Also wires the dependency to the existing `${spock-reports.version}` property so the version lives in exactly one place instead of being duplicated.

## Risk

Minimal — test-only dependency, and all transitives are excluded (`*:*`) so it can't perturb our Groovy/Spock versions.