### PR TITLE
[INT-1901] Fix startup_failure in Release to Sonatype workflow

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -6,7 +6,11 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  packages: write
+  id-token: write
+  actions: read
 
 jobs:
   release:


### PR DESCRIPTION
## Problem

`release-published.yml` (Release Extension to Sonatype) grants the `GITHUB_TOKEN` only `contents: read`. The reusable workflow it calls — `liquibase/build-logic/.github/workflows/extension-release-published.yml@main` — uses **AWS OIDC** (`aws-actions/configure-aws-credentials` with `role-to-assume`) and publishes artifacts, so it declares:

```yaml
permissions:
  contents: write
  pull-requests: write
  packages: write
  id-token: write
  actions: read
```

A reusable workflow's token is **capped by the caller's permissions** — it can't grant itself more than the caller allows. With only `contents: read`, `id-token` and `packages` resolve to `none`, so OIDC authentication fails and the release job hits `startup_failure` the moment a GitHub Release is published.

## Fix

Grant the caller the same permission set the reusable workflow declares.

## Context

This is the **same root cause as the prior INT-1901 fix** (`Fix startup_failure in Attach Artifact to Release workflow`), which patched `attach-artifact-release.yml` but missed this sibling Sonatype-publish workflow. Found during pre-release review.