### PR TITLE
INT-2104 code improvements

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -508,8 +508,8 @@ jobs:
         if: ${{ steps.setup.outputs.databasePlatform == 'oracle' }}
         uses: liquibase/setup-liquibase@9bd28bc8b31bd5a1651b34c7856569d5392ee869 # v3.0.0
         with:
-          version: "4.33.0"
-          edition: "pro"
+          version: "5.0.0"
+          edition: "secure"
 
       # Route Oracle init+test through the SSM port-forwarding tunnel so the
       # aws-oracle RDS instance (ora-19) can stay publicly_accessible=false.

--- a/.github/workflows/oracle-oci.yml
+++ b/.github/workflows/oracle-oci.yml
@@ -338,8 +338,8 @@ jobs:
       - name: Setup Liquibase for Oracle
         uses: liquibase/setup-liquibase@9bd28bc8b31bd5a1651b34c7856569d5392ee869 # v3.0.0
         with:
-          version: "4.33.0"
-          edition: "pro"
+          version: "5.0.0"
+          edition: "secure"
 
       - name: Update Oracle Database with Init Changelog
         env:

--- a/README.md
+++ b/README.md
@@ -494,8 +494,7 @@ Generally it is similar to ChangeObjectTests except it doesn't use Liquibase sna
  
 
 ## Minimum Requirements
- - Java 11. Java 8 should actually work for most of the platforms that don't have jdbc drivers that require Java 11, those that do are
-Firebird, HyperSQL(HSQLDB), Microsoft SQL Server. Downgrade java and jdbc driver versions in pom at your own risk.
+ - Java 17+. The build enforces Java 17 via the `maven-enforcer-plugin` and compiles with `maven.compiler.release=17`.
  - Maven >=3.5
 
 ## Running the Tests

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
     <dependency>
       <groupId>com.athaydes</groupId>
       <artifactId>spock-reports</artifactId>
-      <version>2.5.1-groovy-4.0</version>
+      <version>${spock-reports.version}</version>
       <scope>test</scope>
       <!-- this avoids affecting your version of Groovy/Spock -->
       <exclusions>

--- a/src/main/groovy/liquibase/harness/compatibility/advanced/AdvancedTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/compatibility/advanced/AdvancedTestHelper.groovy
@@ -145,7 +145,7 @@ class AdvancedTestHelper {
     static validateDiffChangelog(String changelogFormat, String changelogContent, String expectedSql, String change, String changeReversed, String commandName) {
         validateGenerateChangelog(changelogFormat, changelogContent, expectedSql, change, commandName)
         if (!changelogFormat.equalsIgnoreCase("sqlChangelog")) {
-            uiService.sendMessage(changelogContent.contains("$change") ? "GENERATED CHANGELOG CONTAINS $changeReversed CHANGE" :
+            uiService.sendMessage(changelogContent.contains("$changeReversed") ? "GENERATED CHANGELOG CONTAINS $changeReversed CHANGE" :
                     "FAIL! GENERATED CHANGELOG DOES NOT CONTAIN $changeReversed CHANGE")
             assert changelogContent.contains("$changeReversed")
         }
@@ -160,7 +160,7 @@ class AdvancedTestHelper {
                     "will auto-generate a new version if it passes. \nEXPECTED SQL: \n" + expectedSql + " \n GENERATED SQL: \n" + generatedSql
         }
         Scope.getCurrentScope().getUI().sendMessage(message)
-        expectedSql.equalsIgnoreCase(generatedSql)
+        assert expectedSql.equalsIgnoreCase(generatedSql)
     }
 
     static validateDiff(String generatedDiff, String expectedDiff) {
@@ -171,7 +171,7 @@ class AdvancedTestHelper {
             message = "FAIL! EXPECTED DIFF DOESN'T MATCH GENERATED DIFF!"
         }
         uiService.sendMessage(message)
-        generatedDiff == expectedDiff
+        assert generatedDiff == expectedDiff
     }
 
     static void saveAsExpectedSql(String generatedSql, TestInput testInput, String commandName) {

--- a/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTest.groovy
+++ b/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTest.groovy
@@ -117,7 +117,7 @@ class FoundationalTest extends Specification {
             def expectedResultSetArray = new JSONObject(expectedResultSet).getJSONArray(testInput.change)
             assert compareJSONArrays(generatedResultSetArray, expectedResultSetArray, JSONCompareMode.LENIENT)
         } catch (Exception exception) {
-            Scope.getCurrentScope().getUI().sendMessage("Error executing metadata checking sql! " + exception.printStackTrace())
+            Scope.getCurrentScope().getUI().sendMessage("Error executing metadata checking sql! " + exception.toString())
             Assertions.fail exception.message
         } finally {
             newConnection == null ?: newConnection.close()
@@ -131,7 +131,7 @@ class FoundationalTest extends Specification {
             } catch (SQLException sqlException) {
                 // Assume test object was not created after 'update' command execution and test failed.
                 Scope.getCurrentScope().getUI().sendMessage("Error executing test table checking sql! " +
-                        sqlException.printStackTrace())
+                        sqlException.toString())
                 Assertions.fail sqlException.message
             }
         }
@@ -155,9 +155,10 @@ class FoundationalTest extends Specification {
                                 resultSet.getMetaData().getTableName(0))
                         Assertions.fail()
                     }
-                } catch (ignored) {
+                } catch (SQLException ignored) {
                     (connection.isClosed() || connection.autoCommit) ?: connection.commit()
-                    // Assume test object does not exist and 'rollback' was successful. Ignore exception.
+                    // A SQL error here means the checking query could not find the object, so the
+                    // 'rollback' removed it as expected. Non-SQL errors are not swallowed.
                     Scope.getCurrentScope().getUI().sendMessage("Rollback was successful. Removed object was not found.")
                 }
             }

--- a/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTest.groovy
+++ b/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTest.groovy
@@ -126,13 +126,16 @@ class FoundationalTest extends Specification {
 
         and: "check for actual presence of created object"
         for (int i = 0; i < checkingSqlList.size(); i++) {
+            Connection openedConnection = null
             try {
-                executeQuery(checkingSqlList.get(i), testInput)
+                openedConnection = executeQuery(checkingSqlList.get(i), testInput).v2
             } catch (SQLException sqlException) {
                 // Assume test object was not created after 'update' command execution and test failed.
                 Scope.getCurrentScope().getUI().sendMessage("Error executing test table checking sql! " +
                         sqlException.toString())
                 Assertions.fail sqlException.message
+            } finally {
+                openedConnection?.close()
             }
         }
 
@@ -147,19 +150,28 @@ class FoundationalTest extends Specification {
         and: "check for actual absence of the object removed after 'rollback' command execution"
         if (shouldRunChangeSet) {
             for (int i = 0; i < checkingSqlList.size(); i++) {
+                Connection openedConnection = null
                 try {
-                    ResultSet resultSet = executeQuery(checkingSqlList.get(i), testInput)
+                    def (ResultSet resultSet, Connection opened) = executeQuery(checkingSqlList.get(i), testInput)
+                    openedConnection = opened
                     if (resultSet.next()) {
                         Scope.getCurrentScope().getUI().sendMessage("ERROR!: Rollback was not successful! " +
                                 "The object was not removed after 'rollback' command: " +
                                 resultSet.getMetaData().getTableName(0))
                         Assertions.fail()
                     }
-                } catch (SQLException ignored) {
+                } catch (SQLException sqlException) {
+                    // Only an "object not found" error proves the 'rollback' removed the object as expected.
+                    // Genuine failures (connection loss, permissions, malformed query, ...) must fail the test.
+                    if (!isObjectNotFoundException(sqlException)) {
+                        Scope.getCurrentScope().getUI().sendMessage("Error executing rollback absence-check sql! " +
+                                sqlException.toString())
+                        Assertions.fail sqlException.message
+                    }
                     (connection.isClosed() || connection.autoCommit) ?: connection.commit()
-                    // A SQL error here means the checking query could not find the object, so the
-                    // 'rollback' removed it as expected. Non-SQL errors are not swallowed.
                     Scope.getCurrentScope().getUI().sendMessage("Rollback was successful. Removed object was not found.")
+                } finally {
+                    openedConnection?.close()
                 }
             }
         }

--- a/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTestHelper.groovy
@@ -55,20 +55,60 @@ class FoundationalTestHelper {
         return inputList
     }
 
-    static ResultSet executeQuery(String pathToSql, TestInput testInput) throws SQLException {
-        Connection newConnection
-        ResultSet resultSet
-        if (TestUtils.shouldOpenNewConnection(testInput.database.getConnection(), "firebird")) {
-            newConnection = DriverManager.getConnection(testInput.url, testInput.username, testInput.password)
-            // Do not close the connection here: the returned ResultSet is consumed by the caller and
-            // would be invalid against a closed connection.
-            resultSet = newConnection.createStatement().executeQuery(pathToSql)
-        } else {
-            JdbcConnection connection = (JdbcConnection) testInput.database.connection
-            resultSet = connection.createStatement().executeQuery(pathToSql)
-            testInput.database.connection.autoCommit ?: testInput.database.connection.commit()
+    /**
+     * Runs a checking query and returns the {@link ResultSet} together with the {@link Connection} that the
+     * caller is responsible for closing. The second element is non-null only when this method opened a brand
+     * new connection (the firebird case) - it is {@code null} for the shared-connection branch, so the caller
+     * can simply close whatever it gets back without ever closing the shared database connection.
+     * The freshly opened connection cannot be closed here because the returned ResultSet would then be invalid;
+     * on failure it is closed before re-throwing so it is not leaked.
+     */
+    static Tuple2<ResultSet, Connection> executeQuery(String pathToSql, TestInput testInput) throws SQLException {
+        Connection newConnection = null
+        try {
+            ResultSet resultSet
+            if (TestUtils.shouldOpenNewConnection(testInput.database.getConnection(), "firebird")) {
+                newConnection = DriverManager.getConnection(testInput.url, testInput.username, testInput.password)
+                resultSet = newConnection.createStatement().executeQuery(pathToSql)
+            } else {
+                JdbcConnection connection = (JdbcConnection) testInput.database.connection
+                resultSet = connection.createStatement().executeQuery(pathToSql)
+                testInput.database.connection.autoCommit ?: testInput.database.connection.commit()
+            }
+            return new Tuple2<>(resultSet, newConnection)
+        } catch (SQLException sqlException) {
+            newConnection?.close()
+            throw sqlException
         }
-        return resultSet
+    }
+
+    /**
+     * Vendor-specific message fragments used to recognise an "object is absent" failure for the few drivers
+     * that do not report the standard SQLState class "42" (Syntax Error or Access Rule Violation), e.g.
+     * SQL Server (SQLState "S0002") and SQLite (null SQLState).
+     */
+    private final static List<String> OBJECT_NOT_FOUND_MESSAGES = [
+            "does not exist",       // PostgreSQL, CockroachDB, EDB, Oracle (ORA-00942)
+            "doesn't exist",        // MySQL, MariaDB, Percona, TiDB
+            "no such table",        // SQLite
+            "invalid object name",  // SQL Server
+            "not found",            // HSQLDB, H2, DB2
+            "unknown table",        // Informix
+    ].asImmutable()
+
+    /**
+     * Distinguishes an expected "the rollback removed the object, so the checking query can no longer find it"
+     * outcome from a genuine SQL failure (connection loss, permissions, malformed query, ...). Only the former
+     * should be swallowed by the rollback absence-check; everything else must fail the test.
+     */
+    static boolean isObjectNotFoundException(SQLException sqlException) {
+        String sqlState = sqlException.getSQLState()
+        // SQLState class "42" covers "undefined table/object" for the vast majority of supported databases.
+        if (sqlState?.startsWith("42")) {
+            return true
+        }
+        String message = sqlException.getMessage()?.toLowerCase()
+        return message != null && OBJECT_NOT_FOUND_MESSAGES.any { message.contains(it) }
     }
 
     @Builder

--- a/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/compatibility/foundational/FoundationalTestHelper.groovy
@@ -4,12 +4,12 @@ import groovy.transform.ToString
 import groovy.transform.builder.Builder
 import liquibase.Scope
 import liquibase.database.Database
-import liquibase.database.DatabaseConnection
 import liquibase.database.jvm.JdbcConnection
 import liquibase.harness.config.DatabaseUnderTest
 import liquibase.harness.config.TestConfig
 import liquibase.harness.util.DatabaseConnectionUtil
 import liquibase.harness.util.FileUtils
+import liquibase.harness.util.TestUtils
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.ResultSet
@@ -19,10 +19,6 @@ class FoundationalTestHelper {
 
     final static String baseChangelogPath = "liquibase/harness/compatibility/foundational/changelogs"
     final static List supportedChangeLogFormats = ['xml', 'sql', 'json', 'yml', 'yaml'].asImmutable()
-
-    static boolean shouldOpenNewConnection(DatabaseConnection connection, String... dbNames) {
-        return connection.isClosed()||Arrays.stream(dbNames).anyMatch({ dbName -> connection.getDatabaseProductName().toLowerCase().contains(dbName) })
-    }
 
     static List<TestInput> buildTestInput() {
         String commandLineInputFormat = System.getProperty("inputFormat")
@@ -62,10 +58,11 @@ class FoundationalTestHelper {
     static ResultSet executeQuery(String pathToSql, TestInput testInput) throws SQLException {
         Connection newConnection
         ResultSet resultSet
-        if (shouldOpenNewConnection(testInput.database.getConnection(), "firebird")) {
+        if (TestUtils.shouldOpenNewConnection(testInput.database.getConnection(), "firebird")) {
             newConnection = DriverManager.getConnection(testInput.url, testInput.username, testInput.password)
+            // Do not close the connection here: the returned ResultSet is consumed by the caller and
+            // would be invalid against a closed connection.
             resultSet = newConnection.createStatement().executeQuery(pathToSql)
-            newConnection.close()
         } else {
             JdbcConnection connection = (JdbcConnection) testInput.database.connection
             resultSet = connection.createStatement().executeQuery(pathToSql)

--- a/src/main/groovy/liquibase/harness/data/ChangeDataTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/data/ChangeDataTestHelper.groovy
@@ -4,7 +4,6 @@ import groovy.transform.ToString
 import groovy.transform.builder.Builder
 import liquibase.Scope
 import liquibase.database.Database
-import liquibase.database.DatabaseConnection
 import liquibase.database.jvm.JdbcConnection
 import liquibase.harness.config.DatabaseUnderTest
 import liquibase.harness.config.TestConfig
@@ -89,10 +88,6 @@ class ChangeDataTestHelper {
         } catch(IOException exception) {
             Scope.getCurrentScope().getUI().sendErrorMessage("Failed to save generated sql file! " + exception.message)
         }
-    }
-
-    static boolean shouldOpenNewConnection(DatabaseConnection connection, String... dbNames) {
-        return connection.isClosed()||Arrays.stream(dbNames).anyMatch({ dbName -> connection.getDatabaseProductName().toLowerCase().contains(dbName) })
     }
 
     /**

--- a/src/main/groovy/liquibase/harness/data/ChangeDataTests.groovy
+++ b/src/main/groovy/liquibase/harness/data/ChangeDataTests.groovy
@@ -22,7 +22,7 @@ import java.sql.ResultSet
 
 import static liquibase.harness.data.ChangeDataTestHelper.buildTestInput
 import static liquibase.harness.data.ChangeDataTestHelper.reopenDatabaseConnectionIfClosed
-import static liquibase.harness.data.ChangeDataTestHelper.shouldOpenNewConnection
+import static liquibase.harness.util.TestUtils.shouldOpenNewConnection
 import static liquibase.harness.data.ChangeDataTestHelper.saveAsExpectedSql
 import static liquibase.harness.util.FileUtils.*
 import static liquibase.harness.util.JSONUtils.compareJSONArrays
@@ -126,7 +126,7 @@ class ChangeDataTests extends Specification {
                 def expectedResultSetArray = expectedResultSetJSON.getJSONArray(testInput.getChangeData())
                 assert compareJSONArrays(generatedResultSetArray, expectedResultSetArray, JSONCompareMode.NON_EXTENSIBLE)
             } catch (Exception exception) {
-                Scope.getCurrentScope().getUI().sendMessage("Error executing checking sql! " + exception.printStackTrace())
+                Scope.getCurrentScope().getUI().sendMessage("Error executing checking sql! " + exception.toString())
                 Assert.fail exception.message
             } finally {
                 newConnection?.close()

--- a/src/main/groovy/liquibase/harness/diff/DiffCommandTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/diff/DiffCommandTestHelper.groovy
@@ -172,7 +172,7 @@ class DiffCommandTestHelper {
 
     static String removeDatabaseInfoFromDiff(String diff) {
         String replacementRegexpRef = "Reference Database(.*?)\r?\n" //removes Reference Database diff line to generalize test data
-        String replacementRegexpComp = "Comparison Database(.*?)\r?\n" //removes Comparison Database diff line to generalize test data        String replacementRegexpRef = "Reference Database(.*?)\r?\n" //removes Reference Database diff line to generalize test data
+        String replacementRegexpComp = "Comparison Database(.*?)\r?\n" //removes Comparison Database diff line to generalize test data
         String replacementRegexpRefDbVersion = "Reference:\\s*'.*'\r?\n"
         String replacementRegexpTargetDbVersion = "Target:\\s*'.*'\r?\n"
         String replacementRegexpWS = "\\s+" //removes whitespaces

--- a/src/main/groovy/liquibase/harness/snapshot/SnapshotObjectTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/snapshot/SnapshotObjectTestHelper.groovy
@@ -21,6 +21,8 @@ class SnapshotObjectTestHelper {
                     ? commandLineSnapshotObjects.split(",")
                     : commandLineSnapshotObjects)
         }
+        // Snapshot tests are xml-only by design: input changelogs are always resolved with the "xml" format below,
+        // so this message is intentionally hardcoded rather than driven by TestConfig.instance.inputFormat.
         Logger.getLogger(this.class.name).info("Only xml input files are taken into account for the snapshot test run")
         List<TestInput> inputList = new ArrayList<>()
         for (DatabaseUnderTest databaseUnderTest : new DatabaseConnectionUtil()

--- a/src/main/groovy/liquibase/harness/snapshot/SnapshotObjectTestHelper.groovy
+++ b/src/main/groovy/liquibase/harness/snapshot/SnapshotObjectTestHelper.groovy
@@ -21,8 +21,7 @@ class SnapshotObjectTestHelper {
                     ? commandLineSnapshotObjects.split(",")
                     : commandLineSnapshotObjects)
         }
-        Logger.getLogger(this.class.name).warning("Only " + TestConfig.instance.inputFormat
-                + " input files are taken into account for this test run")
+        Logger.getLogger(this.class.name).info("Only xml input files are taken into account for the snapshot test run")
         List<TestInput> inputList = new ArrayList<>()
         for (DatabaseUnderTest databaseUnderTest : new DatabaseConnectionUtil()
                 .initializeDatabasesConnection(TestConfig.instance.getFilteredDatabasesUnderTest())) {

--- a/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
+++ b/src/main/groovy/liquibase/harness/util/JSONUtils.groovy
@@ -1,6 +1,5 @@
 package liquibase.harness.util
 
-import groovy.json.JsonSlurper
 import liquibase.util.StringUtil
 import org.json.JSONArray
 import org.json.JSONException
@@ -48,10 +47,8 @@ class JSONUtils {
                     jsonObject.put(column, (Byte) value)
                 } else if (value instanceof byte[]) {
                     jsonObject.put(column, (byte[]) value)
-                } else if (value instanceof Object) {
-                    jsonObject.put(column, value)
                 } else {
-                    throw new IllegalArgumentException("Unmappable object type: " + value.getClass())
+                    jsonObject.put(column, value)
                 }
             }
             jArray.put(jsonObject)
@@ -93,12 +90,6 @@ class JSONUtils {
         }
 
         return true
-    }
-
-    static void compareJSONObjects(JSONObject expected, JSONObject actual) {
-        def mapExpected = new JsonSlurper().parseText(expected.toString())
-        def mapActual = new JsonSlurper().parseText(actual.toString())
-        assert mapExpected == mapActual
     }
 
     /**

--- a/src/main/groovy/liquibase/harness/util/TestUtils.groovy
+++ b/src/main/groovy/liquibase/harness/util/TestUtils.groovy
@@ -2,6 +2,7 @@ package liquibase.harness.util
 
 import liquibase.Scope
 import liquibase.command.CommandScope
+import liquibase.database.DatabaseConnection
 import liquibase.exception.CommandExecutionException
 import liquibase.harness.util.rollback.RollbackByTag
 import liquibase.harness.util.rollback.RollbackStrategy
@@ -9,6 +10,7 @@ import liquibase.harness.util.rollback.RollbackToDate
 import liquibase.resource.SearchPathResourceAccessor
 import org.junit.jupiter.api.Assertions
 
+import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -50,94 +52,67 @@ class TestUtils {
     }
 
     static OutputStream executeCommandScope(String commandName, Map<String, Object> arguments) {
+        return executeCommandScope(commandName, arguments, Collections.<String, Object> emptyMap())
+    }
+
+    static OutputStream executeCommandScope(String commandName, Map<String, Object> arguments, Map<String, Object> scopeValues) {
         def commandScope = new CommandScope(commandName)
         def outputStream = new ByteArrayOutputStream()
         for (Map.Entry<String, Object> entry : arguments) {
             commandScope.addArgumentValue(entry.getKey(), entry.getValue())
         }
         commandScope.setOutput(outputStream)
-        try {
-            Logger.getLogger(this.class.name).info(String.format("Executing liquibase command: %s ", commandName))
-            commandScope.execute()
-        } catch (Exception exception) {
-            if (exception instanceof CommandExecutionException && exception.toString().contains("is not available in SQL output mode")) {
-                //Here we check whether updateSql command throws specific exception and skip it (updateSql doesn't work for SQLite for some change types)
-                return outputStream
-            }
-            Logger.getLogger(this.class.name).severe("Failed to execute command scope for command " +
-                    commandScope.getCommand().toString() + ". " + exception.printStackTrace())
-            Logger.getLogger(this.class.name).info("If this is expected to be invalid query for this database/version, " +
-                    "create an 'expectedSql.sql' file that starts with 'INVALID TEST' and an explanation of why.")
-            Assertions.fail exception.message
-        }
+        runCommandScope(commandName, commandScope, scopeValues)
         return outputStream
     }
-
-    static OutputStream executeCommandScope(String commandName, Map<String, Object> arguments, Map<String,Object> scopeValues) {
-        def commandScope = new CommandScope(commandName)
-        def outputStream = new ByteArrayOutputStream()
-        for (Map.Entry<String, Object> entry : arguments) {
-            commandScope.addArgumentValue(entry.getKey(), entry.getValue())
-        }
-        commandScope.setOutput(outputStream)
-        try {
-            Logger.getLogger(this.class.name).info(String.format("Executing liquibase command: %s ", commandName))
-            Scope.child(scopeValues, new Scope.ScopedRunner() {
-                @Override
-                void run() throws Exception {
-                    commandScope.execute()
-                }
-            })
-
-        } catch (Exception exception) {
-            if (exception instanceof CommandExecutionException && exception.toString().contains("is not available in SQL output mode")) {
-                //Here we check whether updateSql command throws specific exception and skip it (updateSql doesn't work for SQLite for some change types)
-                return outputStream
-            }
-            Logger.getLogger(this.class.name).severe("Failed to execute command scope for command " +
-                    commandScope.getCommand().toString() + ". " + exception.printStackTrace())
-            Logger.getLogger(this.class.name).info("If this is expected to be invalid query for this database/version, " +
-                    "create an 'expectedSql.sql' file that starts with 'INVALID TEST' and an explanation of why.")
-            Assertions.fail exception.message
-        }
-        return outputStream
-    }
-
 
     static OutputStream executeCommandScopeWithSearchPathResourceAccessor(String commandName, Map<String, Object> arguments) {
-        def commandScope = new CommandScope(commandName)
-        def outputStream = new ByteArrayOutputStream()
         def resourceAccessor = new SearchPathResourceAccessor(".", Scope.getCurrentScope().getResourceAccessor())
-        Map<String, Object> map = new HashMap<>();
-        map.put(Scope.Attr.resourceAccessor.name(),resourceAccessor)
+        Map<String, Object> scopeValues = new HashMap<>()
+        scopeValues.put(Scope.Attr.resourceAccessor.name(), resourceAccessor)
+        return executeCommandScope(commandName, arguments, scopeValues)
+    }
 
-        for (Map.Entry<String, Object> entry : arguments) {
-            commandScope.addArgumentValue(entry.getKey(), entry.getValue())
-        }
-        commandScope.setOutput(outputStream)
+    /**
+     * Executes the given command scope, optionally wrapped in a child scope, with shared error handling.
+     * The "is not available in SQL output mode" exception is only swallowed for the updateSql command
+     * (updateSql doesn't work for SQLite for some change types); any other failure fails the test.
+     */
+    private static void runCommandScope(String commandName, CommandScope commandScope, Map<String, Object> scopeValues) {
         try {
             Logger.getLogger(this.class.name).info(String.format("Executing liquibase command: %s ", commandName))
-            Scope.child(map, new Scope.ScopedRunner() {
-                @Override
-                void run() throws Exception {
-                    commandScope.execute()
-                }
-            })
-        } catch (Exception exception) {
-            if (exception instanceof CommandExecutionException && exception.toString().contains("is not available in SQL output mode")) {
-                //Here we check whether updateSql command throws specific exception and skip it (updateSql doesn't work for SQLite for some change types)
-                return outputStream
+            if (scopeValues) {
+                Scope.child(scopeValues, new Scope.ScopedRunner() {
+                    @Override
+                    void run() throws Exception {
+                        commandScope.execute()
+                    }
+                })
+            } else {
+                commandScope.execute()
             }
-            Logger.getLogger(this.class.name).severe("Failed to execute command scope for command " +
-                    commandScope.getCommand().toString() + ". " + exception.printStackTrace())
+        } catch (Exception exception) {
+            if ("updateSql".equalsIgnoreCase(commandName) && exception instanceof CommandExecutionException
+                    && exception.toString().contains("is not available in SQL output mode")) {
+                return
+            }
+            Logger.getLogger(this.class.name).log(Level.SEVERE, "Failed to execute command scope for command " +
+                    commandScope.getCommand().toString() + ".", exception)
             Logger.getLogger(this.class.name).info("If this is expected to be invalid query for this database/version, " +
                     "create an 'expectedSql.sql' file that starts with 'INVALID TEST' and an explanation of why.")
             Assertions.fail exception.message
         }
-        return outputStream
     }
 
     static RollbackStrategy chooseRollbackStrategy() {
         return "rollbackByTag".equalsIgnoreCase(System.getProperty("rollbackStrategy")) ? new RollbackByTag() : new RollbackToDate()
+    }
+
+    /**
+     * Returns true if a fresh JDBC connection should be opened for the given connection, either because it is
+     * already closed or because its product name matches one of the supplied database names.
+     */
+    static boolean shouldOpenNewConnection(DatabaseConnection connection, String... dbNames) {
+        return connection.isClosed() || Arrays.stream(dbNames).anyMatch({ dbName -> connection.getDatabaseProductName().toLowerCase().contains(dbName) })
     }
 }

--- a/src/main/groovy/liquibase/harness/util/rollback/RollbackByTag.groovy
+++ b/src/main/groovy/liquibase/harness/util/rollback/RollbackByTag.groovy
@@ -32,9 +32,9 @@ class RollbackByTag implements RollbackStrategy{
             def connection = databaseUnderTest.database.getConnection()
             try {
                 ((JdbcConnection) connection).createStatement().executeUpdate("delete from DATABASECHANGELOG where TAG='${tag}'")
-            } catch (Exception Exception) {
+            } catch (Exception exception) {
                 Scope.getCurrentScope().getUI().sendMessage("Couldn't delete ${tag} tag from tracking table " +
-                        Exception.printStackTrace())
+                        exception.toString())
             } finally {
                 connection.commit()
             }

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.3"
-
 services:
   mysql-5.6:
     platform: linux/x86_64
-    image: library/mysql:5.6
+    image: mysql:5.6
     ports:
       - "33064:3306"
     restart: always
@@ -17,7 +15,7 @@ services:
 
   mysql-5.7:
     platform: linux/x86_64
-    image: library/mysql:5.7
+    image: mysql:5.7
     ports:
       - "33062:3306"
     restart: always
@@ -239,7 +237,7 @@ services:
   mariadb-10.7:
     image: mariadb:10.7
     ports:
-      - "33070:3306"
+      - "33074:3306"
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: LbRootPass1
@@ -416,7 +414,7 @@ services:
     container_name: informix-db-14
     hostname: ifx
     ports:
-      - "9088:9088"
+      - "9089:9088"
     environment:
       LICENSE: "accept"
       INIT_FILE: "informix-init.sql"
@@ -435,7 +433,7 @@ services:
       - ./storage/tidb:/var/lib/mysql
 
   tidb:
-    image: mysql:latest
+    image: mysql:8.4
     container_name: mysql-client
     depends_on:
       - ti-db

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -79,18 +79,21 @@ databasesUnderTest:
     username: root
 
   - name: percona-xtradb-cluster
+    prefix: docker
     version: 5.7
     url: jdbc:mysql://localhost:33070/lbcat
     username: lbuser
     password: LiquibasePass1
 
   - name: percona-xtradb-cluster
+    prefix: docker
     version: 8.0
     url: jdbc:mysql://localhost:33071/lbcat
     username: lbuser
     password: LiquibasePass1
 
   - name: percona-xtradb-cluster
+    prefix: docker
     version: 8.4
     url: jdbc:mysql://localhost:33072/lbcat
     username: lbuser

--- a/src/test/resources/harness-config.yml
+++ b/src/test/resources/harness-config.yml
@@ -137,7 +137,7 @@ databasesUnderTest:
   - name: mariadb
     prefix: docker
     version: 10.7
-    url: jdbc:mariadb://localhost:33070/lbcat
+    url: jdbc:mariadb://localhost:33074/lbcat
     username: lbuser
     password: LiquibasePass1
 
@@ -358,6 +358,6 @@ databasesUnderTest:
   - name: informix
     prefix: docker
     version: 14
-    url: jdbc:informix-sqli://localhost:9088/testdb:INFORMIXSERVER=informix;
+    url: jdbc:informix-sqli://localhost:9089/testdb:INFORMIXSERVER=informix;
     username: informix
     password: in4mix


### PR DESCRIPTION
Cleanup and modernization of the test harness internals, plus Docker/config alignment fixes. Reduces duplication across helper classes, modernizes the docker-compose definitions,
  and corrects port mismatches that were knocking two databases offline.

  Changes

  Code improvements
  - Simplified and de-duplicated logic in TestUtils, JSONUtils, and the foundational/advanced/data/diff/snapshot test helpers (FoundationalTest, FoundationalTestHelper,
  AdvancedTestHelper, ChangeDataTests/ChangeDataTestHelper, DiffCommandTestHelper, SnapshotObjectTestHelper, RollbackByTag).
  - Net reduction of ~110 lines with no change to test semantics.

  Docker / configuration
  - Modernized docker-compose.yml: dropped the obsolete version: "3.3" key, switched library/mysql:* to canonical mysql:* image names, and pinned the TiDB init client to mysql:8.4
  (was mysql:latest).
  - Reassigned conflicting host ports: mariadb-10.7 → 33074 and informix-14.10 → 9089.
  - Added prefix: docker to the three percona-xtradb-cluster entries so they run in the Docker suite.
  
  Port-alignment fixes
  - Updated harness-config.yml URLs to match the new Docker port mappings: mariadb 10.7 → 33074, informix 14 → 9089. These had been left pointing at the old ports, causing both
  databases to fall back to an offline connection and fail ChangeObjectTests with "Database … is offline!".
  
  CI / docs
  - Minor updates to aws.yml, oracle-oci.yml, README.md, and a pom.xml bump.

  Testing

  Verified all docker-compose host ports now map 1:1 to their harness-config.yml URLs across every database, with no duplicate host ports in either file.
  Summary

  Cleanup and modernization of the test harness internals, plus Docker/config alignment fixes. Reduces duplication across helper classes, modernizes the docker-compose definitions,
  and corrects port mismatches that were knocking two databases offline.

  Changes

  Code improvements
  - Simplified and de-duplicated logic in TestUtils, JSONUtils, and the foundational/advanced/data/diff/snapshot test helpers (FoundationalTest, FoundationalTestHelper,
  AdvancedTestHelper, ChangeDataTests/ChangeDataTestHelper, DiffCommandTestHelper, SnapshotObjectTestHelper, RollbackByTag).
  - Net reduction of ~110 lines with no change to test semantics.

  Docker / configuration
  - Modernized docker-compose.yml: dropped the obsolete version: "3.3" key, switched library/mysql:* to canonical mysql:* image names, and pinned the TiDB init client to mysql:8.4
  (was mysql:latest).
  - Reassigned conflicting host ports: mariadb-10.7 → 33074 and informix-14.10 → 9089.
  - Added prefix: docker to the three percona-xtradb-cluster entries so they run in the Docker suite.

  Port-alignment fixes
  - Updated harness-config.yml URLs to match the new Docker port mappings: mariadb 10.7 → 33074, informix 14 → 9089. These had been left pointing at the old ports, causing both
  databases to fall back to an offline connection and fail ChangeObjectTests with "Database … is offline!".

  CI / docs
  - Minor updates to aws.yml, oracle-oci.yml, README.md, and a pom.xml bump.