### PR TITLE
[TECHOPS-725] Fix test-harness CI infra: pin LocalStack & lpm, guard commit-status step

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -297,7 +297,15 @@ jobs:
     needs: [setup]
     runs-on: ubuntu-latest
     env:
-      LPM_VERSION: 0.2.3
+      # lpm 0.2.x fetched its package manifest from the now-removed `master`
+      # branch of liquibase-package-manager, whose checksums drifted from the
+      # re-published driver artifacts -> "Checksum validation failed". 0.3.x
+      # reads the maintained `main` manifest.
+      LPM_VERSION: 0.3.5
+      # Pin LocalStack to a known-good stable release. Untagged ':latest' pulls
+      # bleeding-edge dev builds (e.g. 2026.7.0.dev22) that regressed the MSSQL
+      # RDS engine and caused "RDS status=error" on scheduled runs.
+      LOCALSTACK_VERSION: "2026.6.0"
     strategy:
       fail-fast: false
       matrix:
@@ -343,14 +351,17 @@ jobs:
           GITHUB_TOKEN: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
           RDS_MYSQL_DOCKER: 1     #https://docs.localstack.cloud/user-guide/aws/rds/#mysql-engine
         run: |
-          pip install localstack awscli-local
-          docker pull localstack/localstack-pro
+          pip install "localstack==${{ env.LOCALSTACK_VERSION }}" awscli-local
+          docker pull localstack/localstack-pro:${{ env.LOCALSTACK_VERSION }}
           localstack auth set-token ${{ env.LOCALSTACK_OAUTH_TOKEN }}
+          # Pin the runtime image (not just the CLI) to the stable tag. IMAGE_NAME
+          # forces `localstack start` to launch the pinned version instead of the
+          # default ':latest' dev build, keeping scheduled runs deterministic.
           # LocalStack starts its own MSSQL container from its default image; the
           # EULA must be forwarded with the LOCALSTACK_ prefix (the bare
           # MSSQL_ACCEPT_EULA triggers a "non-prefixed env var" warning and is
           # not reliably forwarded into the runtime container).
-          LOCALSTACK_MSSQL_ACCEPT_EULA=Y localstack start -d
+          LOCALSTACK_MSSQL_ACCEPT_EULA=Y IMAGE_NAME=localstack/localstack-pro:${{ env.LOCALSTACK_VERSION }} localstack start -d
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30
           echo "Startup complete"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -663,11 +663,22 @@ jobs:
           echo "**Test Result:** ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Coordinate Liquibase-Test-Harness
+        # Only report a commit status back to the triggering Liquibase commit when a
+        # SHA was actually resolved. On scheduled/manual runs liquibaseSha is empty,
+        # and GitHub also drops the setup output entirely when the resolved SHA
+        # collides with a masked secret ("Skip output 'liquibaseSha' since it may
+        # contain secret"). An empty SHA produced a POST to /repos/<owner>/<repo>/
+        # statuses with no SHA segment -> 404 -> failed the whole workflow.
+        if: ${{ always() && needs.setup.outputs.liquibaseSha != '' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.get-token.outputs.token }}
           script: |
-            const helper = require('./.github/util/workflow-helper.js')({github, context});
+            const liquibaseSha = "${{ needs.setup.outputs.liquibaseSha }}";
+            if (!liquibaseSha) {
+              core.warning("No liquibaseSha resolved; skipping commit status report.");
+              return;
+            }
 
             console.log("result is ${{ needs.test.result }}");
 
@@ -682,12 +693,18 @@ jobs:
             const repoName = "${{ needs.setup.outputs.liquibaseRepo }}".split("/")[1];
             console.log("Creating commit status on repository: " + repoName);
 
-            await github.rest.repos.createCommitStatus({
-              "owner": "${{ needs.setup.outputs.liquibaseOwner }}",
-              "repo": repoName,
-              "sha": "${{ needs.setup.outputs.liquibaseSha }}",
-              "state": result,
-              "context": "Run Test-Harness Tests",
-              "description": "Test-Harness tests complete",
-              "target_url": "https://github.com/liquibase/liquibase-test-harness/actions/runs/${{ github.run_id }}"
-            });
+            try {
+              await github.rest.repos.createCommitStatus({
+                "owner": "${{ needs.setup.outputs.liquibaseOwner }}",
+                "repo": repoName,
+                "sha": liquibaseSha,
+                "state": result,
+                "context": "Run Test-Harness Tests",
+                "description": "Test-Harness tests complete",
+                "target_url": "https://github.com/liquibase/liquibase-test-harness/actions/runs/${{ github.run_id }}"
+              });
+            } catch (error) {
+              // Posting a commit status back to Liquibase is best-effort coordination,
+              // not a gate on the test-harness result -- never fail the workflow over it.
+              core.warning(`Failed to create commit status on ${repoName}@${liquibaseSha}: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary

Fixes the three failing test-harness workflows reported in [TECHOPS-725](https://datical.atlassian.net/browse/TECHOPS-725). Root cause for all three is the same theme: **scheduled runs consume unpinned / upstream-mutable resources**, so they break whenever upstream drifts.

| # | Workflow / job | Root cause | Fix |
|---|----------------|-----------|-----|
| 1 | Default Test Execution — `Coordinate Liquibase-Test-Harness` | `needs.setup.outputs.liquibaseSha` arrives **empty** on scheduled runs (GitHub Actions also *drops* the output when the resolved SHA collides with a masked secret — `Skip output 'liquibaseSha' since it may contain secret`). `createCommitStatus` then POSTs to `/repos/<owner>/<repo>/statuses` with **no SHA segment** → `404` → fatal under `github-script` v9. | Guard the step on a non-empty SHA and wrap the API call in `try/catch` (best-effort coordination, never fails the workflow). |
| 2 | AWS Cloud Database Test Execution — `Install liquibase and lpm` | `lpm 0.2.3` fetches its manifest from the **removed `master` branch** of `liquibase-package-manager`; the stale manifest's checksums drift from re-published driver artifacts → `Checksum validation failed. Aborting download.` | Bump `LPM_VERSION` → `0.3.5`, which reads the maintained **`main`** manifest. |
| 3 | AWS Cloud Database Test Execution — `Init AWS RDS MSSQL 2019` | The untagged `localstack/localstack-pro:latest` image served a **dev build `2026.7.0.dev22`** whose MSSQL RDS engine fails to start the SQL Server container (`ContainerStateError`) → `RDS status=error`. (`CreateDBInstance` returns 200 — `--engine-version 2019` is fine.) | Pin LocalStack to stable **`2026.6.0`** via `pip`, `docker pull`, and `IMAGE_NAME` for `localstack start`. |

## Evidence (from the exact failing runs)

- **#1** run `28223081275` (event=`schedule`): Setup log → `##[warning]Skip output 'liquibaseSha' since it may contain secret.`; Finish log → `POST /repos/liquibase/liquibase-pro/statuses - 404` (no SHA in path).
- **#2** run `28223457903`: `Package manifest updated from .../master/internal/app/packages.json` then `Checksum validation failed` ~74ms later (manifest layer, not a driver download). `lpm` `update.go`: `v0.2.3`→`master`, `v0.3.5`→`main`; `master` branch is gone (API 404), `main` manifest auto-updated 06-25.
- **#3** run `28153408867`: LocalStack dump → version `2026.7.0.dev22`, `engine_mssql … ContainerStateError: Container not yet started`. MSSQL passed 06-24 (pre-dev22), failed 06-25 (dev22).

## Verification

- `actionlint` + YAML parse on both files: no new issues (warning count identical to `main`).
- Confirmed `lpm-0.3.5-linux.zip` asset + `update`/`add` commands exist in v0.3.5, and the `main` manifest still contains `mysql`/`postgresql`/`mariadb`/`mssql`.
- Confirmed `localstack/localstack-pro:2026.6.0` Docker tag and PyPI `2026.6.0` exist; `IMAGE_NAME` image-pinning confirmed against LocalStack docs.
- These workflows require Pro/AWS/scheduled secrets and can only run in CI; full validation will come from the scheduled/dispatch runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-725]: https://datical.atlassian.net/browse/TECHOPS-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ