### PR TITLE
Make MariaDB aws_10.6 stored-function snapshots collation-agnostic

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createFunction.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createFunction.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createFunction.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
+            "body": "CREATE FUNCTION `test_function`\\(\\) RETURNS varchar\\(20\\) CHARSET utf8mb4 COLLATE utf8mb4_\\w+\nBEGIN\n                                                RETURN 'Hello';\n                                                END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackage.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`\\(\\) RETURNS varchar\\(20\\) CHARSET utf8mb4 COLLATE utf8mb4_\\w+\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackage.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackage.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackageBody.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`\\(\\) RETURNS varchar\\(20\\) CHARSET utf8mb4 COLLATE utf8mb4_\\w+\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackageBody.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mariadb/aws_10.6/createPackageBody.json
@@ -4,7 +4,7 @@
       "com.datical.liquibase.ext.storedlogic.function.Function": [
         {
           "function": {
-            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
+            "body": "CREATE FUNCTION `test_function`() RETURNS varchar(20) CHARSET utf8mb4 COLLATE utf8mb4_general_ci\nBEGIN\n                                                      RETURN 'Hello';\n                                                      END",
             "name": "test_function"
           }
         }]


### PR DESCRIPTION
## Problem

The **AWS Weekly Cloud Database Test Execution** job `test (mariadb:aws_10.6)` fails on three stored-function snapshot assertions ([run 29674331242](https://github.com/liquibase/liquibase-test-harness/actions/runs/29674331242)):

- `createFunction`
- `createPackage`
- `createPackageBody`

All three assert the same `Function` snapshot and fail with:

```
Could not find match for element {"function":{"name":"test_function",
"body":"CREATE FUNCTION `test_function`() RETURNS varchar(20)
CHARSET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci ..."}}
```

## Root cause

The `mariadb/aws_10.6` version folder is **shared by two workflows that run different MariaDB engines**, and they return different default collations for the stored-function body:

| Workflow | Engine | Returned collation |
|---|---|---|
| `aws-weekly.yml` | real AWS RDS MariaDB 10.6 | `utf8mb4_general_ci` |
| `aws.yml` | LocalStack RDS MariaDB 10.6 | `utf8mb4_uca1400_ai_ci` |

The expected snapshots hard-coded `utf8mb4_uca1400_ai_ci` (set in #1154). That value matches the LocalStack run ([run 29677130464](https://github.com/liquibase/liquibase-test-harness/actions/runs/29677130464) — mariadb job green) but **not** the real-RDS weekly run. A single literal collation can satisfy only one of the two workflows, so simply swapping to `general_ci` would just move the failure to `aws.yml`.

This is a test-data drift issue, not a Liquibase regression — update, snapshot, and rollback all completed successfully.

## Fix

The harness treats the expected snapshot body as a **regex** (`SnapshotHelpers.compareValues` -> `actualValue.matches(expectedValue)`). Make the body collation-agnostic:

- Escape the literal parens (`\(\)`, `\(20\)`) — required so the regex path actually engages instead of falling back to literal equality.
- Wildcard the collation name as `utf8mb4_\w+`.

`utf8mb4_\w+` matches both `utf8mb4_general_ci` and `utf8mb4_uca1400_ai_ci`, so **both workflows pass**. Verified locally with `re.fullmatch` (Java `String.matches` semantics) against both collations for all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
