### PR TITLE
[TECHOPS-993] Grant actions: read for ephemeral-cloud-infra cross-run state restore

### DIFF
--- a/.github/workflows/aws-weekly.yml
+++ b/.github/workflows/aws-weekly.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read # ephemeral-cloud-infra (called below) declares actions: read for its cross-run state restore; a caller that omits it fails validation
 
 jobs:
   setup:

--- a/.github/workflows/snowflake.yml
+++ b/.github/workflows/snowflake.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read # ephemeral-cloud-infra (called below) declares actions: read for its cross-run state restore; a caller that omits it fails validation
 
 jobs:
   setup:


### PR DESCRIPTION
## What
Adds `actions: read` to the top-level permissions of `aws-weekly.yml` and `snowflake.yml`.

## Why
[build-logic #667](https://github.com/liquibase/build-logic/pull/667) (TECHOPS-993) makes the shared `ephemeral-cloud-infra.yml` reusable workflow declare `actions: read` (needed to restore Terraform state from the deploy run on the demo reaper's cross-run teardown). A reusable workflow can only downgrade the caller's `GITHUB_TOKEN`, so a caller that does not grant `actions: read` fails validation with `is requesting 'actions: read', but is only allowed 'actions: none'`. These two workflows call `ephemeral-cloud-infra.yml` with only `contents` + `id-token`, so they need the grant.

## Merge order
**Merge this before build-logic #667** so these workflows keep validating once the reusable workflow starts declaring `actions: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
