### PR TITLE
Drop stale characterOctetLength from PostgreSQL datatypes.datetime snapshot (pgjdbc 42.7.13)

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/datatypes.datetime.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/datatypes.datetime.json
@@ -83,7 +83,6 @@
           "column": {
             "name": "time3wtz",
             "type": {
-              "characterOctetLength": "18\\!\\{java.lang.Integer\\}",
               "decimalDigits": "3\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
@@ -191,7 +190,6 @@
           "column": {
             "name": "timestamp1",
             "type": {
-              "characterOctetLength": "25\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamp"
             }
@@ -201,7 +199,6 @@
           "column": {
             "name": "timestamp1wtz",
             "type": {
-              "characterOctetLength": "31\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -211,7 +208,6 @@
           "column": {
             "name": "timestamp2",
             "type": {
-              "characterOctetLength": "25\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamp"
             }
@@ -221,7 +217,6 @@
           "column": {
             "name": "timestamp2wtz",
             "type": {
-              "characterOctetLength": "31\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -231,7 +226,6 @@
           "column": {
             "name": "timestamp3",
             "type": {
-              "characterOctetLength": "26\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamp"
             }
@@ -241,7 +235,6 @@
           "column": {
             "name": "timestamp3wtz",
             "type": {
-              "characterOctetLength": "32\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -251,7 +244,6 @@
           "column": {
             "name": "timestamp4",
             "type": {
-              "characterOctetLength": "27\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamp"
             }
@@ -261,7 +253,6 @@
           "column": {
             "name": "timestamp4wtz",
             "type": {
-              "characterOctetLength": "33\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -271,7 +262,6 @@
           "column": {
             "name": "timestamp5",
             "type": {
-              "characterOctetLength": "28\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamp"
             }
@@ -281,7 +271,6 @@
           "column": {
             "name": "timestamp5wtz",
             "type": {
-              "characterOctetLength": "34\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -291,7 +280,6 @@
           "column": {
             "name": "timestamp6",
             "type": {
-              "characterOctetLength": "29\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamp"
             }
@@ -301,7 +289,6 @@
           "column": {
             "name": "timestamp6wtz",
             "type": {
-              "characterOctetLength": "35\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -311,7 +298,6 @@
           "column": {
             "name": "timestampe0wtz",
             "type": {
-              "characterOctetLength": "28\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }
@@ -321,7 +307,6 @@
           "column": {
             "name": "timestampewtz",
             "type": {
-              "characterOctetLength": "35\\!\\{java.lang.Integer\\}",
               "dataTypeId": "93\\!\\{java.lang.Integer\\}",
               "typeName": "timestamptz"
             }


### PR DESCRIPTION
## Problem

The **Default Test Execution** CI ([run 31195176597](https://github.com/liquibase/liquibase-test-harness/actions/runs/31195176597)) fails `datatypes.datetime` on **all** PostgreSQL versions (12–17), each at the `time3wtz` column:

```
snapshot.objects…Column[8] Could not find match for element
{"column":{"name":"time3wtz","type":{"characterOctetLength":"18","typeName":"timetz","decimalDigits":"3"}}}
```

Everything else (mysql, mariadb, percona, mssql, edb-postgres, …) is green.

## Root cause — the JDBC driver, not Liquibase

PR #1357 bumped the PostgreSQL JDBC driver **`42.7.11 → 42.7.13`**. pgjdbc 42.7.13 (driver fix [pgjdbc#4231](https://github.com/pgjdbc/pgjdbc/pull/4231)) makes `DatabaseMetaData.getColumns()` return **`null` `CHAR_OCTET_LENGTH` for non-character types**, per the JDBC spec — 42.7.11 wrongly returned a value. Liquibase's `ColumnSnapshotGenerator` just relays the driver output, so the snapshot no longer contains `characterOctetLength` for date/time columns while the fixture still expected it.

This matches the identical issue and fix already confirmed for **liquibase-pro-tests** ([#2947](https://github.com/liquibase/liquibase-pro-tests/pull/2947)) — "updating the test files is the correct fix; no change needed in Liquibase."

## Verification (local, controlled)

Snapshotted the **same** `postgres:16` table with both drivers (same Liquibase core), via `CommandScope("snapshot")`:

| column type | 42.7.11 | 42.7.13 |
|---|---|---|
| `time(3) with time zone` and all date/time types | `characterOctetLength` present | **absent (null)** |
| `varchar`, `text` (character types) | present | **unchanged** |

Only `characterOctetLength` changed (dropped) and only for non-character types; `typeName` / `columnSize` / `decimalDigits` unchanged.

## Fix

Remove `characterOctetLength` from the 15 date/time columns in `expectedSnapshot/postgresql/datatypes.datetime.json`. Because the harness comparison is **LENIENT** (expected ⊆ actual), dropping the field:
- matches the new driver (field absent), and
- stays compatible with older drivers still bundled in released Liquibase (field present but simply no longer asserted).

`datatypes.numeric` and other suites don't assert `characterOctetLength` on non-character columns, so no other fixtures need changing (consistent with CI only flagging `datatypes.datetime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
