### PR TITLE
Align all codeql-action steps to v4.37.6 (supersedes #1379, #1381)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -72,6 +72,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
## Problem

CodeQL `Analyze (java)` fails on every PR/branch run with:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.37.0'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.36.2', but running version '4.37.0'
```

All `github/codeql-action/*` steps must run the **same** version. In `codeql.yml`, `init`/`autobuild` were on v4.36.2 while a dependabot bump moved `analyze` to v4.37.0 — so the analyze post-action aborts on the version mismatch (after autobuild succeeds, so it never reflects an actual code finding).

## Fix

Pin all three steps to the same version, **v4.37.6** (`5595ccaf912efad79be6eef63a5619ff05969be3`):

```
github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3      # v4.37.6
github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.37.6
```

Verified: `github/codeql-action` tag `v4.37.6` → commit `5595ccaf912efad79be6eef63a5619ff05969be3`.

## Supersedes the dependabot PRs

v4.37.6 is exactly the version dependabot targets in the existing open PRs:
- #1379 — bump `analyze` 4.37.0 → 4.37.6
- #1381 — bump `init` 4.36.2 → 4.37.6

**Merging those two alone would NOT fix the problem** — there is no dependabot PR for `autobuild`, so it would remain at v4.36.2 and keep the steps mismatched. This PR bumps all three together (including `autobuild`), so #1379 and #1381 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
