### PR TITLE
SECURE-545 Postgres TIME(N): expect precision in columnSize, not decimalDigits (waits for liquibase6)

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/datatypes.datetime.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/datatypes.datetime.json
@@ -29,6 +29,7 @@
           "column": {
             "name": "time0",
             "type": {
+              "columnSize": "0\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -151,6 +152,7 @@
           "column": {
             "name": "timee0wtz",
             "type": {
+              "columnSize": "0\\!\\{java.lang.Integer\\}",
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/datatypes.datetime.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/datatypes.datetime.json
@@ -20,7 +20,7 @@
           "column": {
             "name": "time",
             "type": {
-              "decimalDigits": "6\\!\\{java.lang.Integer\\}",
+              "columnSize": "6\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -29,7 +29,6 @@
           "column": {
             "name": "time0",
             "type": {
-              "decimalDigits": "0\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -38,7 +37,7 @@
           "column": {
             "name": "time1",
             "type": {
-              "decimalDigits": "1\\!\\{java.lang.Integer\\}",
+              "columnSize": "1\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -47,7 +46,7 @@
           "column": {
             "name": "time1wtz",
             "type": {
-              "decimalDigits": "1\\!\\{java.lang.Integer\\}",
+              "columnSize": "1\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -56,7 +55,7 @@
           "column": {
             "name": "time2",
             "type": {
-              "decimalDigits": "2\\!\\{java.lang.Integer\\}",
+              "columnSize": "2\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -65,7 +64,7 @@
           "column": {
             "name": "time2wtz",
             "type": {
-              "decimalDigits": "2\\!\\{java.lang.Integer\\}",
+              "columnSize": "2\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -74,7 +73,7 @@
           "column": {
             "name": "time3",
             "type": {
-              "decimalDigits": "3\\!\\{java.lang.Integer\\}",
+              "columnSize": "3\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -83,7 +82,7 @@
           "column": {
             "name": "time3wtz",
             "type": {
-              "decimalDigits": "3\\!\\{java.lang.Integer\\}",
+              "columnSize": "3\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -93,7 +92,7 @@
             "name": "time4",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "4\\!\\{java.lang.Integer\\}",
+              "columnSize": "4\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -103,7 +102,7 @@
             "name": "time4wtz",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "4\\!\\{java.lang.Integer\\}",
+              "columnSize": "4\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -113,7 +112,7 @@
             "name": "time5",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "5\\!\\{java.lang.Integer\\}",
+              "columnSize": "5\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -123,7 +122,7 @@
             "name": "time5wtz",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "5\\!\\{java.lang.Integer\\}",
+              "columnSize": "5\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -133,7 +132,7 @@
             "name": "time6",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "6\\!\\{java.lang.Integer\\}",
+              "columnSize": "6\\!\\{java.lang.Integer\\}",
               "typeName": "time"
             }
           }
@@ -143,7 +142,7 @@
             "name": "time6wtz",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "6\\!\\{java.lang.Integer\\}",
+              "columnSize": "6\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -153,7 +152,6 @@
             "name": "timee0wtz",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "0\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }
@@ -163,7 +161,7 @@
             "name": "timeewtz",
             "type": {
               "dataTypeId": "92\\!\\{java.lang.Integer\\}",
-              "decimalDigits": "6\\!\\{java.lang.Integer\\}",
+              "columnSize": "6\\!\\{java.lang.Integer\\}",
               "typeName": "timetz"
             }
           }


### PR DESCRIPTION
## ⚠️ Merge order

**This must merge *after* the corresponding Liquibase change (liquibase-pro PR #4582, commit `b911786e`).** Landing it earlier inverts the problem — the harness would then assert the new shape against a Liquibase that still emits the old one.

## Summary

Updates `expectedSnapshot/postgresql/datatypes.datetime.json` for a change in how Liquibase snapshots PostgreSQL `TIME(N)` columns.

Previously `COLUMN_SIZE` held the JDBC display-width (12 for `TIME(3)`, 15 for `TIME(6)` — the character length of the string form) and the fractional-second precision lived in `DECIMAL_DIGITS`. `ColumnSnapshotGenerator` now applies the same normalisation the `TIMESTAMP` branch already did: the precision is stored in `columnSize` and `decimalDigits` is cleared.

That change fixes a real defect on the Liquibase side — a Postgres `diff-changelog` previously emitted a bare `newDataType="time"`, silently downgrading a `TIME(6)` column to `TIME(0)` on deploy.

## Why the golden has to change

The comparison is `JSONAssert` in `JSONCompareMode.LENIENT` (`SnapshotHelpers.GeneralSnapshotComparator`). Under LENIENT, extra keys in the *actual* document are ignored — so the newly-added `columnSize` alone would not fail. But every key present in the *expected* document must still be present and match, and all 16 `TIME`/`TIMETZ` columns assert `decimalDigits`, which is no longer emitted. Without this update those 16 comparisons fail.

## The change

`+14/-16` across 16 columns:

```diff
-  "decimalDigits": "6\!\{java.lang.Integer\}",
+  "columnSize": "6\!\{java.lang.Integer\}",
```

Two details worth calling out, because a mechanical find-and-replace gets both wrong:

1. **`TIME(0)` and `TIMETZ(0)` get no size key at all.** The generator stores the precision only when it is greater than zero, so `time0` and `timee0wtz` now assert neither `columnSize` nor `decimalDigits` — not `columnSize: 0`.
2. The values are **regex patterns**, not literals (the comparator calls `actualValue.matches(expectedValue)`), so the existing escaping is preserved verbatim rather than regenerated.

## How the expected values were derived

Not by hand. Taken from a measured snapshot of the same column set — `TIME`, `TIME(0)`…`TIME(6)`, `TIMETZ`, `TIMETZ(0)`, `TIMETZ(6)` — on PostgreSQL 17 against a build carrying the change. All 16 entries match the observed output, and the file still parses as valid JSON.

## Scope

* No other golden in the repo asserts `decimalDigits` on a `time`/`timetz` column, so this is the only affected expected-snapshot file.
* `expectedSql/postgresql/datatypes.datetime.sql` is **unaffected** — the deploy-direction DDL is byte-identical before and after, including the `time (6)` (space before paren) form used in the changelog.
* `cockroachdb` and `edb-*` fall back to the generic `datatypes.datetime.json`, whose single time entry carries no `decimalDigits`.
* MySQL/MariaDB goldens are unaffected; the normalisation is gated on `AbstractPostgresDatabase`.

## Not yet run against a live harness

Verified by matching measured Liquibase output against the golden and by reading the LENIENT comparison semantics — I have not executed the harness suite itself. Worth a real PostgreSQL run before merge.
