### PR TITLE
Align MySQL/PostgreSQL fixtures with liquibase-pro main (spatial types, clustered PK)

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/datatypes.spatial.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/datatypes.spatial.json
@@ -21,7 +21,7 @@
           "column": {
             "name": "POINT",
             "type": {
-              "typeName": "GEOMETRY"
+              "typeName": "POINT"
             }
           }
         },
@@ -29,7 +29,7 @@
 			  "column": {
 				  "name": "LINESTRING",
 				  "type": {
-					  "typeName": "GEOMETRY"
+					  "typeName": "LINESTRING"
 				  }
 			  }
 		  },
@@ -37,7 +37,7 @@
 			  "column": {
 				  "name": "POLYGON",
 				  "type": {
-					  "typeName": "GEOMETRY"
+					  "typeName": "POLYGON"
 				  }
 			  }
 		  },
@@ -45,7 +45,7 @@
 			  "column": {
 				  "name": "MULTIPOINT",
 				  "type": {
-					  "typeName": "GEOMETRY"
+					  "typeName": "MULTIPOINT"
 				  }
 			  }
 		  },
@@ -53,7 +53,7 @@
 			  "column": {
 				  "name": "MULTILINESTRING",
 				  "type": {
-					  "typeName": "GEOMETRY"
+					  "typeName": "MULTILINESTRING"
 				  }
 			  }
 		  },
@@ -61,7 +61,7 @@
 			  "column": {
 				  "name": "MULTIPOLYGON",
 				  "type": {
-					  "typeName": "GEOMETRY"
+					  "typeName": "MULTIPOLYGON"
 				  }
 			  }
 		  },
@@ -69,7 +69,7 @@
 			  "column": {
 				  "name": "GEOMETRYCOLLECTION",
 				  "type": {
-					  "typeName": "GEOMETRY"
+					  "typeName": "GEOMCOLLECTION"
 				  }
 			  }
 		  }

--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/addClusteredPrimaryKey.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/postgresql/addClusteredPrimaryKey.json
@@ -15,7 +15,6 @@
       "liquibase.structure.core.Index": [
         {
           "index": {
-            "clustered": true,
             "name": "pk_clustered",
             "unique": true
           }


### PR DESCRIPTION
## Summary

The **Default Test Execution** run [31755645722](https://github.com/liquibase/liquibase-test-harness/actions/runs/31755645722) (built against `liquibase-commercial main-138db00`) surfaced several MySQL-family / PostgreSQL failures. I built `liquibase-pro` from source at `138db00`, captured the actual values, and traced each to its Pro commit — then classified each as **intended change** (→ fixture update) vs **suspected bug** (→ flag upstream, do **not** bake in).

This PR contains only the **two intended changes**.

## Included (intended Pro changes)

| Test | DBs | liquibase-pro change | Old → New |
|------|-----|----------------------|-----------|
| `datatypes.spatial` | mysql, percona | **SECURE-483/499** — `ProMySQLColumnMetadataService` projects `UPPER(DATA_TYPE) AS TYPE_NAME` from `information_schema` | each spatial column → its specific type (was generic `GEOMETRY`) |
| `addClusteredPrimaryKey` | postgresql | **DAT-22344** — "Fix PostgreSQL index snapshot"; Postgres has no persistent clustered indexes | index `clustered:true` → **omitted** |

**Why these are correct (not bugs):**
- *spatial*: reporting the specific type (`POINT` for a POINT column) is more accurate than the generic `GEOMETRY` and round-trips cleanly. Captured exactly (incl. the `GEOMETRYCOLLECTION → GEOMCOLLECTION` edge case, since MySQL stores it as `geomcollection`).
- *clustered*: PostgreSQL genuinely can't have a persistent clustered index, so omitting the attribute is more correct. Dropping it (rather than setting `false`) is **LENIENT-safe for both** older builds (still emit `clustered:true`) and pro-main (omit it).

### Exact spatial mapping (captured from pro built at `138db00`)
```
GEOMETRY → GEOMETRY          MULTIPOINT       → MULTIPOINT
POINT    → POINT             MULTILINESTRING  → MULTILINESTRING
LINESTRING → LINESTRING      MULTIPOLYGON     → MULTIPOLYGON
POLYGON  → POLYGON           GEOMETRYCOLLECTION → GEOMCOLLECTION
```

## Deliberately excluded — suspected liquibase-pro bugs

- **`createFunctionIndex`** — Pro emits a **redundant** extra paren: `(((lower(first_name))))` vs the valid `((lower(first_name)))`. The changelog already parenthesizes the computed column (`name="(lower(first_name))"`), and OSS already emits the valid form, but Pro's **SECURE-410** `ProMysqlCreateIndexColumnExpressionService` wraps unconditionally (`return "(" + expression + ")"`) with no guard for an already-parenthesized expression. Should be fixed in liquibase-pro (skip wrapping when the expression is already parenthesized), not papered over here.
- **`createSynonym`** (db2-luw, same run) — throws `UnexpectedLiquibaseException: null snapshotId for schema SYSPUBLIC`, a serialization exception → Liquibase bug, not a fixture.

## Version-skew note

Both included changes track liquibase-pro `main`. `addClusteredPrimaryKey` (removal) is safe for community/released too; `datatypes.spatial` tracks pro-main and would fail on builds that predate SECURE-483/499 until those ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
