### PR TITLE
datatypes.spatial: tolerate MySQL 5.x GEOMETRYCOLLECTION vs 8.x GEOMCOLLECTION

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/datatypes.spatial.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/datatypes.spatial.json
@@ -69,7 +69,7 @@
 			  "column": {
 				  "name": "GEOMETRYCOLLECTION",
 				  "type": {
-					  "typeName": "GEOMCOLLECTION"
+					  "typeName": "GEOM(ETRY)?COLLECTION"
 				  }
 			  }
 		  }


### PR DESCRIPTION
## Problem

Scheduled Default run [32696077598](https://github.com/liquibase/liquibase-test-harness/actions/runs/32696077598) (build `liquibase-commercial main-1b64a1f`) fails `datatypes.spatial` on **mysql 5.6/5.7 and percona 5.7** — and only at the `GEOMETRYCOLLECTION` column:

```
Column[7] Could not find match for element
{"column":{"name":"GEOMETRYCOLLECTION","type":{"typeName":"GEOMCOLLECTION"}}}
```
MySQL 8.x passes.

## Root cause — MySQL version difference, not a Liquibase bug

The spatial `typeName` comes from Pro's `UPPER(INFORMATION_SCHEMA.COLUMNS.DATA_TYPE)` (SECURE-483/499). MySQL reports the `GEOMETRYCOLLECTION` type differently by version:

| MySQL version | `DATA_TYPE` | Pro `typeName` |
|---|---|---|
| 5.6 / 5.7 (verified on 5.7.44) | `geometrycollection` | `GEOMETRYCOLLECTION` |
| 8.0+ | `geomcollection` | `GEOMCOLLECTION` |

Liquibase reports the DB's value verbatim, so this is correct behavior — the #1391 fixture (captured on mysql-8) just needs to also accept the 5.x spelling. The other 7 spatial columns are identical across versions.

## Fix

The harness snapshot comparison treats expected values as **regex**, so widen only the `GEOMETRYCOLLECTION` column's `typeName` to `GEOM(ETRY)?COLLECTION`, which matches both `GEOMCOLLECTION` (8.x) and `GEOMETRYCOLLECTION` (5.x). Verified full-match against both; the 5.7 value confirmed against MySQL 5.7.44 `information_schema`.

Affects mysql + percona only (tidb marks spatial `INVALID TEST`; mariadb has no spatial changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
