### PR TITLE
datatypes.spatial: add mysql 5.6 override (all spatial report GEOMETRY)

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSnapshot/mysql/5.6/datatypes.spatial.json
+++ b/src/main/resources/liquibase/harness/change/expectedSnapshot/mysql/5.6/datatypes.spatial.json
@@ -1,0 +1,79 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "datatypes.spatial_test_table"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+        "column": {
+            "name": "GEOMETRY",
+            "type": {
+              "typeName": "GEOMETRY"
+            }
+          }
+        },
+        {
+          "column": {
+            "name": "POINT",
+            "type": {
+              "typeName": "GEOMETRY"
+            }
+          }
+        },
+		  {
+			  "column": {
+				  "name": "LINESTRING",
+				  "type": {
+					  "typeName": "GEOMETRY"
+				  }
+			  }
+		  },
+		  {
+			  "column": {
+				  "name": "POLYGON",
+				  "type": {
+					  "typeName": "GEOMETRY"
+				  }
+			  }
+		  },
+		  {
+			  "column": {
+				  "name": "MULTIPOINT",
+				  "type": {
+					  "typeName": "GEOMETRY"
+				  }
+			  }
+		  },
+		  {
+			  "column": {
+				  "name": "MULTILINESTRING",
+				  "type": {
+					  "typeName": "GEOMETRY"
+				  }
+			  }
+		  },
+		  {
+			  "column": {
+				  "name": "MULTIPOLYGON",
+				  "type": {
+					  "typeName": "GEOMETRY"
+				  }
+			  }
+		  },
+		  {
+			  "column": {
+				  "name": "GEOMETRYCOLLECTION",
+				  "type": {
+					  "typeName": "GEOMETRY"
+				  }
+			  }
+		  }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Default run [32779023275](https://github.com/liquibase/liquibase-test-harness/actions/runs/32779023275) (build `main-1b64a1f`, on the #1397 merge commit) fails `datatypes.spatial` on **mysql-5.6** at the `POINT` column:
```
Column[?] Could not find match for element {"column":{"name":"POINT","type":{"typeName":"POINT"}}}
```

## Root cause — MySQL 5.6 reports all spatial as GEOMETRY (not a bug)

Pro's specific-spatial-type snapshotting comes from the `information_schema` **bulk-metadata** path (`UPPER(DATA_TYPE)`, SECURE-483/499), which is **gated to MySQL 5.7+**. On **5.6** Liquibase falls back to JDBC `DatabaseMetaData.getColumns()`, which returns `TYPE_NAME = GEOMETRY` for every spatial column.

Verified by snapshotting a **5.6.51** table with the pro build — every spatial column (`POINT`, `LINESTRING`, `GEOMETRYCOLLECTION`, …) reports `GEOMETRY`. (The raw `information_schema.DATA_TYPE` says `point` etc., but Liquibase doesn't use that path on 5.6.)

The shared root `datatypes.spatial.json` holds the specific types captured on 5.7/8 (`POINT`, …, `GEOM(ETRY)?COLLECTION` from #1397), so 5.6 fails at the first specific column.

**Not a Liquibase bug** — MySQL 5.6 is EOL, and `GEOMETRY` is a valid supertype for these columns; extending the bulk path to 5.6 isn't warranted.

## Fix

Add a version-specific `expectedSnapshot/mysql/5.6/datatypes.spatial.json` with all 8 spatial columns' `typeName = GEOMETRY`. Scope:
- **mysql 5.6** → this new override.
- **mysql 5.7 / 8.x, percona** → unchanged root fixture (specific types).
- **tidb** → spatial is `INVALID TEST` (skipped); **mariadb** → no spatial changelog.

---
Note: the same run's `mariadb-10.4` failure is unrelated — a Maven Central `429 Too Many Requests` while resolving `surefire-junit-platform:3.5.6` (infra flake; a re-run clears it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
