### PR TITLE
Quote EDB synonym identifier in createSynonym/dropSynonym expected SQL (SECURE-689)

### DIFF
--- a/src/main/resources/liquibase/harness/change/expectedSql/edb-edb/createSynonym.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/edb-edb/createSynonym.sql
@@ -1,1 +1,1 @@
-CREATE OR REPLACE PUBLIC SYNONYM test_synonym FOR public.authors
+CREATE OR REPLACE PUBLIC SYNONYM "test_synonym" FOR public.authors

--- a/src/main/resources/liquibase/harness/change/expectedSql/edb-edb/dropSynonym.sql
+++ b/src/main/resources/liquibase/harness/change/expectedSql/edb-edb/dropSynonym.sql
@@ -1,2 +1,2 @@
-CREATE OR REPLACE PUBLIC SYNONYM test_synonym FOR public.authors
-DROP SYNONYM test_synonym
+CREATE OR REPLACE PUBLIC SYNONYM "test_synonym" FOR public.authors
+DROP SYNONYM "test_synonym"


### PR DESCRIPTION
## Problem

Default run [32815463481](https://github.com/liquibase/liquibase-test-harness/actions/runs/32815463481) (build `main-7fcd0fc`) fails `createSynonym` and `dropSynonym` on all **edb-edb** versions:

```
expected:  CREATE OR REPLACE PUBLIC SYNONYM test_synonym FOR public.authors
generated: CREATE OR REPLACE PUBLIC SYNONYM "test_synonym" FOR public.authors
           DROP SYNONYM "test_synonym"           (dropSynonym)
```
The synonym name is now emitted as a **quoted identifier**.

## Root cause — intentional liquibase-pro fix (SECURE-689), not a bug

[liquibase-pro] **SECURE-689** ("force-quote synonym identifier" / "fix EDB synonym quote accumulation across generate-changelog round-trips") changed `CreateSynonymGenerator`/`DropSynonymGenerator` to force-quote the synonym name (replacing the previous `escapeObjectName`, which left lowercase names unquoted). It fixes a round-trip quote-accumulation/case defect, so `"test_synonym"` is the intended output.

## Fix

Quote the synonym name in the edb-edb `expectedSql` to match:
- `change/expectedSql/edb-edb/createSynonym.sql`
- `change/expectedSql/edb-edb/dropSynonym.sql`

Only edb-edb runs these (edb-postgres/Oracle unaffected in this run).

## Version-skew note
Tracks liquibase-pro `main`; the SQL comparison is exact, so builds without SECURE-689 (released / older pro) still emit the unquoted name and would fail this fixture until the change ships.

---
Same run also failed `mysql-5.6` (spatial) — already covered by #1398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
