### PR TITLE
[TECHOPS-1222] Read liquibase builds from main.yml / snapshot-branch.yml

### DIFF
--- a/.github/util/workflow-helper.js
+++ b/.github/util/workflow-helper.js
@@ -156,6 +156,16 @@ module.exports = ({github, context}) => {
                         returnData.pullRequestState = pulls.data[0].state;
                     }
 
+                    // TECHOPS-1222: run-tests.yml was retired with the pull_request_target
+                    // CI it belonged to. It built both main and feature branches; that is now
+                    // split between main.yml (push to main, nightly cron) and
+                    // snapshot-branch.yml (maintainer workflow_dispatch for a ref), so the
+                    // workflow to read depends on the branch being resolved.
+                    const workflowFile = (branchName === "main" || branchName === "master")
+                        ? "main.yml"
+                        : "snapshot-branch.yml";
+                    console.log(`Reading runs of ${workflowFile} for branch ${branchName}`);
+
                     let pageNumber = 1;
                     const maxPagesToCheck = 10;
                     let matchingBuildFound = false;
@@ -165,13 +175,16 @@ module.exports = ({github, context}) => {
                             let runs = await github.rest.actions.listWorkflowRuns({
                                 "owner": owner,
                                 "repo": repo,
-                                "workflow_id": "run-tests.yml",
+                                "workflow_id": workflowFile,
                                 "per_page": 100,
                                 "page": pageNumber,
                             });
 
                             if (runs.data.workflow_runs.length !== 0) {
                                 for (let run of runs.data.workflow_runs) {
+                                    // Unreachable for main.yml / snapshot-branch.yml, neither of
+                                    // which uses pull_request_target. Kept so that a run predating
+                                    // the cutover is still filtered the same way. [TECHOPS-1222]
                                     if (run.event === 'pull_request_target') {
                                         if (!returnData.pullRequestId) {
                                             console.log("Skipping pull_request_target from non-pull-request build " + run.html_url);


### PR DESCRIPTION
Part of the [TECHOPS-1222](https://datical.atlassian.net/browse/TECHOPS-1222) cutover.

`liquibase/liquibase`'s `run-tests.yml` is being retired: it is the last `pull_request_target` workflow there and the reason a fork PR could reach release credentials (GHSA-mqw2-j77g-6486).

**Corrected after review: this is narrower than it first looked.** Nothing in this repo reads the fields this lookup fills in. The callers take `.sha` and nothing else, and the real artifact resolution happens elsewhere, against GitHub Packages `maven-metadata.xml` matched on `<sha>-SNAPSHOT`. A missing workflow file gives a 404 that the helper already catches, and it still returns the sha.

So the change keeps the logged build metadata honest rather than fixing a broken resolution, and this is **not** a blocking dependency for the cutover. Two things follow from that: the 7-day run-artifact retention that affects liquibase-pro-tests does not reach this repo at all, and nothing here breaks if this lands after the file is deleted.

Still worth doing. `workflow-helper.js` reads a workflow by literal filename:

## The mapping

`run-tests.yml` built **both** `main` and feature branches. That is now split in two, so a flat rename would be wrong:

| Producer | When it runs |
|---|---|
| `main.yml` | push to `main`, nightly cron |
| `snapshot-branch.yml` | maintainer `workflow_dispatch` for a ref |

The workflow to read therefore depends on the branch being resolved:

```js
const workflowFile = (branchName === "main" || branchName === "master")
    ? "main.yml"
    : "snapshot-branch.yml";
```

Same mapping applied to liquibase-pro-tests in liquibase/liquibase-pro-tests#3209.

The `head_branch` filter below is unchanged and still works for both: dispatching `snapshot-branch.yml` with `--ref <branch>` attributes the run to that branch.

The `pull_request_target` skip is now unreachable, since neither producer uses that event. I left it in place with a note rather than deleting it, so that a run predating the cutover is still filtered the same way.

## Operational change

Branch builds of liquibase are no longer automatic. `build-branch.yml` published a SNAPSHOT on every PR push; TECHOPS-1104 removed that deliberately, because it ran fork-controlled code with `packages: write` and `secrets: inherit`. To resolve a liquibase feature branch now, dispatch it first:

```bash
gh workflow run snapshot-branch.yml --repo liquibase/liquibase \
   --ref <branch> -f ref=<branch>
```

Dispatching with `--ref` is what attributes the run to that branch. Passing only `-f ref=` from `main` produces a run attributed to `main`, and the `head_branch` filter will not match it.

## Verification: both paths exercised against the live API

I was able to test this without spending a QA run, by driving the same code CI drives.

**The Maven path** (`liquibase-sdk-maven-plugin:0.11.0:install-snapshot-cli`, run locally):

| workflowId | branchSearch | Result |
|---|---|---|
| `main.yml` | `main` | BUILD SUCCESS, 45 files, CLI reports `main/3/b13387` |
| `snapshot-branch.yml` | `main` | resolved, downloaded `liquibase-zip-main` from run [33714175993](https://github.com/liquibase/liquibase/actions/runs/33714175993) |
| `snapshot-branch.yml` | `techops-1222-cutover,main` | BUILD SUCCESS, resolved `liquibase:techops-1222-cutover`, downloaded `liquibase-zip-techops-1222-cutover`, CLI reports `techops-1222-cutover/2/6dfd62` |

The third row is the feature-branch path, the one that changes most. To produce it I dispatched the new branch builder and it worked first time:

```bash
gh workflow run snapshot-branch.yml --repo liquibase/liquibase \
   --ref techops-1222-cutover -f ref=techops-1222-cutover
```

Run [33726722662](https://github.com/liquibase/liquibase/actions/runs/33726722662) completed successfully with `head_branch=techops-1222-cutover`, producing `liquibase-zip-techops-1222-cutover` and `liquibase-artifacts-techops-1222-cutover`. That confirms the `--ref` requirement documented above: it is what attributes the run to the branch the plugin filters on.

**The JavaScript path** (`workflow-helper.js` `findMatchingBranch`, driven against the real API with a shim for the three methods it uses, `repos.getBranch` / `pulls.list` / `actions.listWorkflowRuns`):

| Branch | Resolved to |
|---|---|
| `main` | `main.yml` run #3, `conclusion: success` |
| `techops-1222-cutover` | `snapshot-branch.yml` run #2, `conclusion: success` |

**One related check:** the file header says this helper is copy-pasted across repos, so I checked every copy. `liquibase-pro` has one that still names `run-tests.yml`, but a clone of all 111 files under its `.github` confirms nothing there requires the helper or calls `findMatchingBranch`. It is dead code, not a consumer, so it needs no change for this cutover.

A real QA run is of course still welcome, but this is no longer a blind merge.


[TECHOPS-1222]: https://datical.atlassian.net/browse/TECHOPS-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
