### PR TITLE
feat: Add a Tests Complete gate the DB matrix can actually fail [TECHOPS-1034]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -708,3 +708,21 @@ jobs:
               // not a gate on the test-harness result -- never fail the workflow over it.
               core.warning(`Failed to create commit status on ${repoName}@${liquibaseSha}: ${error.message}`);
             }
+
+  tests-complete:
+    name: Tests Complete
+    runs-on: ubuntu-latest
+    needs: [setup, test]
+    # The merge gate. Kept separate from `finish`, which pulls vault creds and an
+    # App token and would go red on fork PRs for reasons unrelated to the tests.
+    if: ${{ always() }}
+    steps:
+      - name: Verify the database matrix passed
+        run: |
+          # No selective dispatcher here, so 'skipped' is a failure, not a pass.
+          setup_result="${{ needs.setup.result }}"
+          test_result="${{ needs.test.result }}"
+          echo "setup=${setup_result} test=${test_result}"
+          if [ "$setup_result" != "success" ] || [ "$test_result" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -713,8 +713,8 @@ jobs:
     name: Tests Complete
     runs-on: ubuntu-latest
     needs: [setup, test]
-    # The merge gate. Kept separate from `finish`, which pulls vault creds and an
-    # App token and would go red on fork PRs for reasons unrelated to the tests.
+    # The merge gate. Separate from `finish`, whose vault, App-token and cross-repo
+    # status steps can fail for reasons that have nothing to do with the test results.
     if: ${{ always() }}
     steps:
       - name: Verify the database matrix passed


### PR DESCRIPTION
## Problem

`main.yml` has no job whose result reflects the database matrix. `finish` runs with `if: always()` and reads `needs.test.result` only to report a commit status to the triggering build - that call sits in a `try/catch` which downgrades errors to `core.warning`, so no step in it can ever exit non-zero.

The result is that `finish` succeeds on runs where matrix legs failed. On #1357 it reported success alongside six failing postgres legs.

## Fix

Adds a `tests-complete` job (check name `Tests Complete`) that exits non-zero unless both `setup` and `test` report success, so one status reflects the whole matrix.

## Notes

- `skipped` is treated as a failure: every job here is unconditional, so a skipped  matrix always means something went wrong upstream.
- Separate job rather than a step in `finish`, which pulls vault credentials and an App token and would fail on fork PRs for reasons unrelated to the tests.
- Aggregates rather than exposing the legs individually: the matrix comes from `fromJson(needs.setup.outputs.databases)` and is overridable via `workflow_dispatch` / `repository_dispatch`, so leg names vary between runs.